### PR TITLE
breaking(rds/postgres): require master credentials

### DIFF
--- a/rds/postgres/README.md
+++ b/rds/postgres/README.md
@@ -40,11 +40,7 @@ Creates an RDS PostgreSQL database instance
 
 * `password` (`string`, required)
 
-    Password for the master DB user, if not provided a random one will be generated
-
-* `password_length` (`number`, default: `32`)
-
-    Random password length
+    Password for the master DB user
 
 * `port` (`number`, default: `5432`)
 
@@ -84,11 +80,7 @@ Creates an RDS PostgreSQL database instance
 
 * `username` (`string`, required)
 
-    Username for the master DB user, if not provided a random one will be generated
-
-* `username_length` (`number`, default: `8`)
-
-    Random username length
+    Username for the master DB user
 
 * `vpc_id` (`string`, required)
 

--- a/rds/postgres/example/main.tf
+++ b/rds/postgres/example/main.tf
@@ -21,6 +21,11 @@ data "aws_subnet" "b" {
   default_for_az    = true
 }
 
+resource "random_string" "password" {
+  length  = 32
+  special = false
+}
+
 module "db" {
   source = "./.."
 
@@ -34,6 +39,8 @@ module "db" {
   instance_type = "db.t2.micro"
   storage       = 20
   public        = true
+  username      = "admin"
+  password      = random_string.password.result
 
   prevent_destroy = false
 }

--- a/rds/postgres/main.tf
+++ b/rds/postgres/main.tf
@@ -1,8 +1,6 @@
 locals {
-  name     = "${var.project}-${var.environment}"
-  db       = var.db != null ? var.db : replace(var.project, "-", "_")
-  username = var.create && var.username == null ? random_string.username[0].result : var.username
-  password = var.create && var.password == null ? random_string.password[0].result : var.password
+  name = "${var.project}-${var.environment}"
+  db   = var.db != null ? var.db : replace(var.project, "-", "_")
 
   default_tags = {
     Name        = local.name
@@ -11,20 +9,6 @@ locals {
   }
 
   tags = merge(local.default_tags, var.tags)
-}
-
-resource "random_string" "username" {
-  count = var.create && var.username == null ? 1 : 0
-
-  length  = var.username_length
-  special = false
-}
-
-resource "random_string" "password" {
-  count = var.create && var.password == null ? 1 : 0
-
-  length  = var.password_length
-  special = false
 }
 
 resource "aws_db_subnet_group" "db" {
@@ -91,8 +75,8 @@ resource "aws_db_instance" "db" {
 
   port     = var.port
   name     = local.db
-  username = local.username
-  password = local.password
+  username = var.username
+  password = var.password
 
   tags = local.tags
 }

--- a/rds/postgres/outputs.tf
+++ b/rds/postgres/outputs.tf
@@ -15,16 +15,16 @@ output "db" {
 
 output "username" {
   description = "DB master username"
-  value       = local.username
+  value       = var.username
 }
 
 output "password" {
   description = "DB master password"
-  value       = local.password
+  value       = var.password
 }
 
 output "url" {
   description = "DB connection url"
-  value       = var.create ? "postgres://${local.username}:${local.password}@${aws_db_instance.db[0].address}:${aws_db_instance.db[0].port}/${local.db}" : null
+  value       = var.create ? "postgres://${var.username}:${var.password}@${aws_db_instance.db[0].address}:${aws_db_instance.db[0].port}/${local.db}" : null
 }
 

--- a/rds/postgres/variables.tf
+++ b/rds/postgres/variables.tf
@@ -33,27 +33,13 @@ variable "port" {
 }
 
 variable "username" {
-  description = "Username for the master DB user, if not provided a random one will be generated"
+  description = "Username for the master DB user"
   type        = string
-  default     = null
-}
-
-variable "username_length" {
-  description = "Random username length"
-  type        = number
-  default     = 8
 }
 
 variable "password" {
-  description = "Password for the master DB user, if not provided a random one will be generated"
+  description = "Password for the master DB user"
   type        = string
-  default     = null
-}
-
-variable "password_length" {
-  description = "Random password length"
-  type        = number
-  default     = 32
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
Moved the responsibility for generating random master credentials to the user of `rds/postgres`.

This is due to an issue with `count` when a variable value is provided by a resource attribute, eg. 

```tf
resource "random_string" "foo" {
  length = 8
}

resource "random_string" "bar" {
  count = random_string.foo.result != null ? 1 : 0
  length = 8
}
```

will fail with

```
Error: Invalid count argument

  on main.tf line 6, in resource "random_string" "bar":
   6:   count  = random_string.foo.result != null ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

because terraform isn't smart enough to know that `random_string.foo.result` can't be `null`, it just assumes any resource output is completely unknown.

Unfortunately this is exactly what happens when a user tries to use `ecs/postgres` with master credentials generated using `random_string` (or any other resource).