### PR TITLE
feat(ssl/acm): Added validated_arn output

### DIFF
--- a/ssl/acm/README.md
+++ b/ssl/acm/README.md
@@ -40,3 +40,7 @@ Creates an SSL certificate using AWS ACM, verifies domain ownership using Route5
 * `id`
 
     ACM certificate id
+
+* `validated_arn`
+
+    ACM certificate ARN, once it's validated

--- a/ssl/acm/example/main.tf
+++ b/ssl/acm/example/main.tf
@@ -24,6 +24,5 @@ module "certificate" {
 }
 
 output "certificate_arn" {
-  value = module.certificate.arn
+  value = module.certificate.validated_arn
 }
-

--- a/ssl/acm/main.tf
+++ b/ssl/acm/main.tf
@@ -12,9 +12,6 @@ resource "aws_acm_certificate" "cert" {
   }
 }
 
-# https://github.com/hashicorp/terraform/issues/18359
-# Workaround that can deal with up to 4 domains
-
 resource "aws_acm_certificate_validation" "cert" {
   count = var.create ? 1 : 0
 

--- a/ssl/acm/outputs.tf
+++ b/ssl/acm/outputs.tf
@@ -8,3 +8,7 @@ output "arn" {
   value       = var.create ? aws_acm_certificate.cert[0].arn : null
 }
 
+output "validated_arn" {
+  description = "ACM certificate ARN, once it's validated"
+  value       = var.create && aws_acm_certificate_validation.cert[0].id != null ? aws_acm_certificate.cert[0].arn : null
+}


### PR DESCRIPTION
- [x] added `validated_arn` output to force any resources using it to wait till the ACM certificate is validated, otherwise there's a good chance apply will fail