### PR TITLE
refactor(ecs/repository)!: added image_name variable

### DIFF
--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -38,7 +38,8 @@ module "hosts" {
 module "repo" {
   source = "./../repository"
 
-  project = local.project
+  project    = local.project
+  image_name = "httpbin"
 }
 
 module "worker_task" {

--- a/ecs/repository/README.md
+++ b/ecs/repository/README.md
@@ -17,6 +17,10 @@ Creates an ECR repository and a policy for CI which allows push/pull access.
 
     Should resources be created
 
+* `image_name` (`string`, required)
+
+    Container image name
+
 * `project` (`string`, required)
 
     Kebab-cased project name

--- a/ecs/repository/main.tf
+++ b/ecs/repository/main.tf
@@ -1,6 +1,7 @@
 locals {
+  name = "${var.project}/${var.image_name}"
   default_tags = {
-    Name    = var.project
+    Name    = local.name
     Project = var.project
   }
 
@@ -10,7 +11,7 @@ locals {
 resource "aws_ecr_repository" "repo" {
   count = var.create ? 1 : 0
 
-  name = var.project
+  name = local.name
   tags = local.tags
 }
 
@@ -40,8 +41,8 @@ data "aws_iam_policy_document" "ci" {
 resource "aws_iam_policy" "ci" {
   count = var.create ? 1 : 0
 
-  name        = "${var.project}-repo-ci"
-  description = "Allows a user to push and pull from the ${var.project} docker repository"
+  name        = "${replace(local.name, "/", "-")}-repo-ci"
+  description = "Allows a user to push and pull from the ${local.name} image repository"
   policy      = data.aws_iam_policy_document.ci[0].json
 }
 

--- a/ecs/repository/variables.tf
+++ b/ecs/repository/variables.tf
@@ -9,6 +9,11 @@ variable "project" {
   type        = string
 }
 
+variable "image_name" {
+  description = "Container image name"
+  type        = string
+}
+
 variable "tags" {
   description = "Tags to add to resources that support them"
   type        = map(string)


### PR DESCRIPTION
ECR repositories are meant to be created one per image, as in you can only add tags. To reflect that, added an `image_name` variable which is appended to the repository name.

- [x] added a required variable `image_name` to `ecs/repository`
- [x] renamed ecs repository to `project/image_name`

Both of the above are breaking changes.