### PR TITLE
fix: is empty tuple errors on terraform >=0.12.11

### DIFF
--- a/ecs/task/log_group/main.tf
+++ b/ecs/task/log_group/main.tf
@@ -34,6 +34,6 @@ locals {
       "awslogs-region"        = data.aws_region.current[0].name
       "awslogs-stream-prefix" = aws_cloudwatch_log_group.log[0].name
     }
-  } : {}
+  } : null
 }
 

--- a/ecs/task/log_group/main.tf
+++ b/ecs/task/log_group/main.tf
@@ -27,13 +27,13 @@ data "aws_region" "current" {
 }
 
 locals {
-  container_log_config = {
+  container_log_config = var.create ? {
     "logDriver" = "awslogs"
     "options" = {
       "awslogs-group"         = aws_cloudwatch_log_group.log[0].name
       "awslogs-region"        = data.aws_region.current[0].name
       "awslogs-stream-prefix" = aws_cloudwatch_log_group.log[0].name
     }
-  }
+  } : {}
 }
 

--- a/ecs/task/log_group/outputs.tf
+++ b/ecs/task/log_group/outputs.tf
@@ -15,5 +15,5 @@ output "container_config" {
 
 output "container_config_json" {
   description = "Container definition logging configuration JSON"
-  value       = var.create ? jsonencode(local.container_log_config) : null
+  value       = var.create && local.container_log_config != null ? jsonencode(local.container_log_config) : null
 }

--- a/ecs/task/main.tf
+++ b/ecs/task/main.tf
@@ -2,7 +2,7 @@ locals {
   family    = "${var.project}-${var.environment}-${var.task}"
   container = var.container != null ? var.container : var.task
 
-  image_tag = var.image_tag != null ? var.image_tag : data.aws_ecs_container_definition.current[0].image_digest
+  image_tag = var.image_tag != null ? var.image_tag : join("", data.aws_ecs_container_definition.current.*.image_digest)
   image     = var.image != null ? var.image : "${var.image_name}:${local.image_tag}"
 }
 

--- a/spa/main.tf
+++ b/spa/main.tf
@@ -196,7 +196,7 @@ module "basic_auth" {
   create = var.create && var.basic_auth_credentials != null
 
   name     = "${local.name_prefix}-basic-auth"
-  code     = data.template_file.basic_auth[0].rendered
+  code     = join("", data.template_file.basic_auth.*.rendered)
   role_arn = module.middleware_common.role_arn
   tags     = local.tags
 
@@ -220,7 +220,7 @@ module "pull_request_router" {
   create = var.create && var.pull_request_router
 
   name     = "${local.name_prefix}-pull-request-router"
-  code     = data.template_file.pull_request_router[0].rendered
+  code     = join("", data.template_file.pull_request_router.*.rendered)
   role_arn = module.middleware_common.role_arn
   tags     = local.tags
 

--- a/ssl/acm/outputs.tf
+++ b/ssl/acm/outputs.tf
@@ -10,5 +10,8 @@ output "arn" {
 
 output "validated_arn" {
   description = "ACM certificate ARN, once it's validated"
-  value       = var.create && aws_acm_certificate_validation.cert[0].id != null ? aws_acm_certificate.cert[0].arn : null
+
+  # aws_acm_certificate_validation.cert != null will always be true
+  # and is only used to force a dependency on validation
+  value = var.create && aws_acm_certificate_validation.cert != null ? aws_acm_certificate.cert[0].arn : null
 }


### PR DESCRIPTION
Fixes issues with conditional resource creation (eg. `var.create`) found by Terraform >= 0.12.11
https://github.com/hashicorp/terraform/issues/23222

There might be more of these hidden somewhere in the code, we'll deal with the rest of them as they surface...