### PR TITLE
feat(ses/domain): added mx_records variable and spf_record output

### DIFF
--- a/ses/domain/README.md
+++ b/ses/domain/README.md
@@ -72,6 +72,10 @@ Registers a domain with AWS SES and verifies it
 
     email server ip/domain, if omitted SES will be used for incomming emails
 
+* `mx_records` (`list(string)`, required)
+
+    MX records to be included
+
 * `name` (`string`, required)
 
     Domain name to register with SES
@@ -91,6 +95,10 @@ Registers a domain with AWS SES and verifies it
 * `spf_ip6` (`list(string)`, required)
 
     IPv6 addresses to include in the SPF record
+
+* `txt_records` (`list(string)`, required)
+
+    TXT records to be included
 
 
 

--- a/ses/domain/README.md
+++ b/ses/domain/README.md
@@ -82,7 +82,7 @@ Registers a domain with AWS SES and verifies it
 
 * `spf` (`bool`, default: `true`)
 
-    Whether to add an SPF record
+    Whether to add a TXT record with SPF. If you need additional TXT records, create your own aws_route53_record and add the `spf_record` output to it
 
 * `spf_include` (`list(string)`, required)
 
@@ -96,10 +96,6 @@ Registers a domain with AWS SES and verifies it
 
     IPv6 addresses to include in the SPF record
 
-* `txt_records` (`list(string)`, required)
-
-    TXT records to be included
-
 
 
 ## Outputs
@@ -111,3 +107,7 @@ Registers a domain with AWS SES and verifies it
 * `sender_policy_name`
 
     IAM policy name for email senders
+
+* `spf_record`
+
+    SPF record which you should include in the domain's TXT record in case you specified `spf = false`

--- a/ses/domain/README.md
+++ b/ses/domain/README.md
@@ -74,7 +74,7 @@ Registers a domain with AWS SES and verifies it
 
 * `mx_records` (`list(string)`, required)
 
-    MX records to be included
+    MX records that point to your email servers, if omitted SES will be used for incomming emails
 
 * `name` (`string`, required)
 

--- a/ses/domain/README.md
+++ b/ses/domain/README.md
@@ -70,7 +70,7 @@ Registers a domain with AWS SES and verifies it
 
 * `mail_server` (`string`, required)
 
-    email server ip/domain, if omitted SES will be used for incomming emails
+    **DEPRECATED, use `mx_records = ['10 {mail_server}']` instead**.<br/>Email server ip/domain, if omitted SES will be used for incomming emails
 
 * `mx_records` (`list(string)`, required)
 

--- a/ses/domain/main.tf
+++ b/ses/domain/main.tf
@@ -60,17 +60,17 @@ locals {
     [for ip in var.spf_ip4 : "ip4:${ip}"],
     [for ip in var.spf_ip6 : "ip6:${ip}"],
   )
+  spf_record = var.spf ? ["v=spf1 ${join(" ", local.spf_entries)} -all"] : []
 }
 
 resource "aws_route53_record" "txt" {
-  count      = var.create && (var.spf || length(var.txt_records) > 0) ? 1 : 0
-  spf_record = var.spf ? ["v=spf1 ${join(" ", local.spf_entries)} -all"] : []
+  count = var.create && (var.spf || length(var.txt_records) > 0) ? 1 : 0
 
   zone_id = var.hosted_zone_id
   name    = "${local.domain}."
   type    = "TXT"
   ttl     = 300
-  records = flatten([spf_record, var.txt_records])
+  records = flatten([local.spf_record, var.txt_records])
 }
 
 # DKIM ------------------------------------------------------------------------

--- a/ses/domain/main.tf
+++ b/ses/domain/main.tf
@@ -58,7 +58,7 @@ resource "aws_route53_record" "mx" {
   name    = "${local.domain}."
   type    = "MX"
   ttl     = 300
-  records = ["10 ${local.mail_server}"]
+  records = length(var.mx_records) == 0 ? ["10 ${local.mail_server}"] : var.mx_records
 }
 
 # SPF -------------------------------------------------------------------------

--- a/ses/domain/main.tf
+++ b/ses/domain/main.tf
@@ -65,17 +65,17 @@ locals {
     [for ip in var.spf_ip4 : "ip4:${ip}"],
     [for ip in var.spf_ip6 : "ip6:${ip}"],
   )
-  spf_record = var.spf ? ["v=spf1 ${join(" ", local.spf_entries)} -all"] : []
+  spf_record = "v=spf1 ${join(" ", local.spf_entries)} -all"
 }
 
 resource "aws_route53_record" "txt" {
-  count = var.create && (var.spf || length(var.txt_records) > 0) ? 1 : 0
+  count = var.create && var.spf ? 1 : 0
 
   zone_id = var.hosted_zone_id
   name    = "${local.domain}."
   type    = "TXT"
   ttl     = 300
-  records = flatten([local.spf_record, var.txt_records])
+  records = [local.spf_record]
 }
 
 # DKIM ------------------------------------------------------------------------

--- a/ses/domain/main.tf
+++ b/ses/domain/main.tf
@@ -26,6 +26,16 @@ resource "aws_route53_record" "ses_verification" {
   records = [aws_ses_domain_identity.domain[0].verification_token]
 }
 
+resource "aws_route53_record" "txt" {
+  count = var.create && length(var.txt_records) > 0 ? 1 : 0
+
+  zone_id = var.hosted_zone_id
+  name    = "${local.domain}."
+  type    = "TXT"
+  ttl     = 300
+  records = var.txt_records
+}
+
 resource "aws_ses_domain_identity_verification" "domain" {
   count      = var.create ? 1 : 0
   depends_on = [aws_route53_record.ses_verification]

--- a/ses/domain/main.tf
+++ b/ses/domain/main.tf
@@ -38,7 +38,12 @@ resource "aws_ses_domain_identity_verification" "domain" {
 locals {
   ses_incomming_region = var.incomming_region != null ? var.incomming_region : local.region
   ses_incomming_server = "inbound-smtp.${local.ses_incomming_region}.amazonaws.com."
-  mail_server          = var.mail_server != null ? var.mail_server : local.ses_incomming_server
+
+  mx_records = (
+    var.mx_records != null ? var.mx_records :
+    var.mail_server != null ? ["10 ${var.mail_server}"] :
+    ["10 ${local.ses_incomming_server}"]
+  )
 }
 
 resource "aws_route53_record" "mx" {
@@ -48,7 +53,7 @@ resource "aws_route53_record" "mx" {
   name    = "${local.domain}."
   type    = "MX"
   ttl     = 300
-  records = length(var.mx_records) == 0 ? ["10 ${local.mail_server}"] : var.mx_records
+  records = local.mx_records
 }
 
 # SPF -------------------------------------------------------------------------

--- a/ses/domain/main.tf
+++ b/ses/domain/main.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 resource "aws_route53_record" "txt" {
-  count = var.create && (var.spf || length(var.txt_records) > 0) ? 1 : 0
+  count      = var.create && (var.spf || length(var.txt_records) > 0) ? 1 : 0
   spf_record = var.spf ? ["v=spf1 ${join(" ", local.spf_entries)} -all"] : []
 
   zone_id = var.hosted_zone_id

--- a/ses/domain/outputs.tf
+++ b/ses/domain/outputs.tf
@@ -1,3 +1,8 @@
+output "spf_record" {
+  description = "SPF record which you should include in the domain's TXT record in case you specified `spf = false`"
+  value       = local.spf_record
+}
+
 output "sender_policy_name" {
   description = "IAM policy name for email senders"
   value       = var.create ? aws_iam_policy.sender[0].name : null

--- a/ses/domain/variables.tf
+++ b/ses/domain/variables.tf
@@ -98,6 +98,12 @@ variable "dmarc_report_emails" {
   default     = []
 }
 
+variable "mx_records" {
+  description = "MX records to be included"
+  type        = list(string)
+  default     = []
+}
+
 variable "txt_records" {
   description = "TXT records to be included"
   type        = list(string)

--- a/ses/domain/variables.tf
+++ b/ses/domain/variables.tf
@@ -39,7 +39,7 @@ variable "dkim" {
 }
 
 variable "spf" {
-  description = "Whether to add an SPF record"
+  description = "Whether to add a TXT record with SPF. If you need additional TXT records, create your own aws_route53_record and add the `spf_record` output to it"
   type        = bool
   default     = true
 }
@@ -100,12 +100,6 @@ variable "dmarc_strict_spf_alignment" {
 
 variable "dmarc_report_emails" {
   description = "E-mail addresses that SMTP servers should send DMARC reports to"
-  type        = list(string)
-  default     = []
-}
-
-variable "txt_records" {
-  description = "TXT records to be included"
   type        = list(string)
   default     = []
 }

--- a/ses/domain/variables.tf
+++ b/ses/domain/variables.tf
@@ -21,9 +21,9 @@ variable "mail_server" {
 }
 
 variable "mx_records" {
-  description = "MX records to be included"
+  description = "MX records that point to your email servers, if omitted SES will be used for incomming emails"
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "incomming_region" {

--- a/ses/domain/variables.tf
+++ b/ses/domain/variables.tf
@@ -97,3 +97,9 @@ variable "dmarc_report_emails" {
   type        = list(string)
   default     = []
 }
+
+variable "txt_records" {
+  description = "TXT records to be included"
+  type        = list(string)
+  default     = []
+}

--- a/ses/domain/variables.tf
+++ b/ses/domain/variables.tf
@@ -15,9 +15,15 @@ variable "hosted_zone_id" {
 }
 
 variable "mail_server" {
-  description = "email server ip/domain, if omitted SES will be used for incomming emails"
+  description = "**DEPRECATED, use `mx_records = ['10 {mail_server}']` instead**.<br/>Email server ip/domain, if omitted SES will be used for incomming emails"
   type        = string
   default     = null
+}
+
+variable "mx_records" {
+  description = "MX records to be included"
+  type        = list(string)
+  default     = []
 }
 
 variable "incomming_region" {
@@ -94,12 +100,6 @@ variable "dmarc_strict_spf_alignment" {
 
 variable "dmarc_report_emails" {
   description = "E-mail addresses that SMTP servers should send DMARC reports to"
-  type        = list(string)
-  default     = []
-}
-
-variable "mx_records" {
-  description = "MX records to be included"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
We need a way to provide custom TXT & MX records in order to verify domain for third party like G Suite. It would probably be used as follows:

```
module "ses_domain" {
  source = "github.com/codequest-eu/terraform-modules?ref=xxx//ses/domain"
  create = var.create
  providers = {
    aws = aws.ses
  }

  # ...
  
  txt_records = ["google-site-verification=xxx"]
  mx_records = [
    "1 ASPMX.L.GOOGLE.COM",
    "5 ALT1.ASPMX.L.GOOGLE.COM",
    "5 ALT2.ASPMX.L.GOOGLE.COM",
    "10 ALT3.ASPMX.L.GOOGLE.COM",
    "10 ALT4.ASPMX.L.GOOGLE.COM",
  ]
}
```
