### PR TITLE
fix(ecs/host_group): unable to update launch configuration

### DIFF
--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -38,13 +38,17 @@ data "template_file" "user_data" {
 resource "aws_launch_configuration" "hosts" {
   count = var.create ? 1 : 0
 
-  name                 = local.full_name
+  name_prefix          = "${local.full_name}-"
   image_id             = data.aws_ami.ecs_amazon_linux[0].id
   instance_type        = var.instance_type
   security_groups      = [var.security_group_id]
   iam_instance_profile = var.instance_profile
   user_data            = data.template_file.user_data[0].rendered
   key_name             = var.bastion_key_name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_group" "hosts" {


### PR DESCRIPTION
Switched to `name_prefix` for `aws_launch_configuration` so it can be updated with `create_before_destroy`.

AWS Launch Configurations are immutable, so you need to create a new one with the desired changes every time. By default terraform first tries to remove the old configuration and then create a new one to avoid name collisions, however that fails, because the old configuration is still attached to the auto scaling group. We need to create a new one first, update the auto scaling group and then remove the old configuration.