### PR TITLE
chore(ecs/network): updated NAT instance AMI

### DIFF
--- a/ecs/network/main.tf
+++ b/ecs/network/main.tf
@@ -151,6 +151,10 @@ resource "aws_eip_association" "public_nat" {
 
   instance_id   = aws_instance.nat[count.index].id
   allocation_id = aws_eip.public_nat[count.index].id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "nat" {

--- a/ecs/network/main.tf
+++ b/ecs/network/main.tf
@@ -121,7 +121,7 @@ data "aws_ami" "nat" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-vpc-nat-2018.03.0.20190611-x86_64-ebs"]
+    values = ["amzn-ami-vpc-nat-2018.03.0.20200318.1-x86_64-ebs"]
   }
 }
 
@@ -140,6 +140,10 @@ resource "aws_instance" "nat" {
   )
   key_name          = aws_key_pair.bastion[0].key_name
   source_dest_check = false
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_eip_association" "public_nat" {


### PR DESCRIPTION
- [x] Updated NAT instance AMI to `amzn-ami-vpc-nat-2018.03.0.20200318.1-x86_64-ebs`
- [x] Enabled `create_before_destroy` for NAT `aws_instance`s to minimize downtime
- [x] Added waiting for the new nat instance to be ready before switching to it to minimize downtime further
