### PR TITLE
feat(ecs/host_group): added detailed_monitoring variable

### DIFF
--- a/ecs/host_group/README.md
+++ b/ecs/host_group/README.md
@@ -30,6 +30,10 @@ Creates an auto-scaling group of EC2 instances which will join the given ECS clu
 
     Should resources be created
 
+* `detailed_monitoring` (`bool`, default: `true`)
+
+    Whether to enable detailed monitoring on EC2 instances
+
 * `environment` (`string`, required)
 
     Kebab-cased environment name, eg. development, staging, production.

--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -45,6 +45,7 @@ resource "aws_launch_configuration" "hosts" {
   iam_instance_profile = var.instance_profile
   user_data            = data.template_file.user_data[0].rendered
   key_name             = var.bastion_key_name
+  enable_monitoring    = var.detailed_monitoring
 
   lifecycle {
     create_before_destroy = true

--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -31,7 +31,8 @@ data "template_file" "user_data" {
   template = file("${path.module}/templates/user_data.sh")
 
   vars = {
-    cluster_name = var.cluster_name
+    cluster_name        = var.cluster_name
+    detailed_monitoring = var.detailed_monitoring
   }
 }
 

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -19,6 +19,6 @@ unzip CloudWatchMonitoringScripts-1.2.2.zip && \
 rm CloudWatchMonitoringScripts-1.2.2.zip
 
 cat >/etc/cron.d/ec2_metrics <<EOF
-* * * * * ec2-user /opt/aws-scripts-mon/mon-put-instance-data.pl --from-cron --mem-util --mem-used --mem-avail --swap-util --swap-used
-* * * * * ec2-user /opt/aws-scripts-mon/mon-put-instance-data.pl --from-cron --disk-path=/ --disk-space-util --disk-space-used --disk-space-avail
+*${detailed_monitoring ? "" : "/5"} * * * * ec2-user /opt/aws-scripts-mon/mon-put-instance-data.pl --from-cron --mem-util --mem-used --mem-avail --swap-util --swap-used
+*${detailed_monitoring ? "" : "/5"} * * * * ec2-user /opt/aws-scripts-mon/mon-put-instance-data.pl --from-cron --disk-path=/ --disk-space-util --disk-space-used --disk-space-avail
 EOF

--- a/ecs/host_group/variables.tf
+++ b/ecs/host_group/variables.tf
@@ -79,3 +79,9 @@ variable "bastion_key_name" {
   type        = string
 }
 
+variable "detailed_monitoring" {
+  description = "Whether to enable detailed monitoring on EC2 instances"
+  type        = bool
+  default     = true
+}
+


### PR DESCRIPTION
- [x] Added `detailed_monitoring` variable which controls whether detailed monitoring should be switched on, defaults to `true` for backwards compatibility
- [x] Lowered the monitoring schedules to every 5 minutes if `detailed_monitoring` is off

Closes #41 