### PR TITLE
feat(ecs/host_group): added autoscaling group metrics

### DIFF
--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -64,6 +64,17 @@ resource "aws_autoscaling_group" "hosts" {
   desired_capacity = var.size
   max_size         = local.max_size
 
+  enabled_metrics = var.detailed_monitoring ? [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ] : null
+
   dynamic "tag" {
     for_each = local.tags
     content {


### PR DESCRIPTION
- [x] Added autoscaling group metrics when detailed monitoring is on

Closes #44 