### PR TITLE
feat(ecs/host_group): automatic updates

### DIFF
--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -4,6 +4,13 @@ echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
 # Update ECS agent
 yum update -y ecs-init
 
+# Keep the ECS agent up to date
+cat >/etc/cron.daily/ecs-agent-update <<EOF
+#!/bin/sh
+date >>/var/log/ecs/ecs-init-update.log
+yum update -y ecs-init >>/var/log/ecs/ecs-init-update.log 2>&1
+EOF
+
 # Install security updates
 yum update -y --security
 

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -53,6 +53,9 @@ apply_updates = no
 random_sleep = 0
 EOF
 
+systemctl enable yum-cron
+systemctl start yum-cron
+
 # Enable docker daemon live restore, so we can update docker without
 # restarting containers
 # https://docs.docker.com/config/containers/live-restore/
@@ -61,9 +64,7 @@ cat >/etc/docker/daemon.json <<EOF
   "live-restore": true
 }
 EOF
-
-systemctl enable yum-cron
-systemctl start yum-cron
+systemctl restart docker
 
 # Setup memory and disk usage monitoring
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -3,12 +3,17 @@ echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
 
 # Update ECS agent
 yum update -y ecs-init
+docker pull amazon/amazon-ecs-agent:latest
 
 # Keep the ECS agent up to date
 cat >/etc/cron.daily/ecs-agent-update <<EOF
 #!/bin/sh
-date >>/var/log/ecs/ecs-init-update.log
-yum update -y ecs-init >>/var/log/ecs/ecs-init-update.log 2>&1
+{
+  date
+  yum update -y ecs-init
+  docker pull amazon/amazon-ecs-agent:latest
+  systemctl restart ecs
+} >>/var/log/ecs/ecs-init-update.log 2>&1
 EOF
 chmod +x /etc/cron.daily/ecs-agent-update
 

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -10,6 +10,7 @@ cat >/etc/cron.daily/ecs-agent-update <<EOF
 date >>/var/log/ecs/ecs-init-update.log
 yum update -y ecs-init >>/var/log/ecs/ecs-init-update.log 2>&1
 EOF
+chmod +x /etc/cron.daily/ecs-agent-update
 
 # Install security updates
 yum update -y --security

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -21,6 +21,12 @@ cat >/etc/cron.daily/ecs-agent-update <<EOF
 EOF
 chmod +x /etc/cron.daily/ecs-agent-update
 
+# HACK:
+# For some reason simply doing docker pull amazon/amazon-ecs-agent:latest
+# in the user data script doesn't fully update the ECS agent, so
+# lets force running the daily script once ECS starts up
+nohup sh -c 'while ! systemctl is-active -q ecs; do sleep 5; done; /etc/cron.daily/ecs-agent-update' &
+
 # Install security updates
 yum update -y --security
 

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -47,7 +47,7 @@ EOF
 # Enable docker daemon live restore, so we can update docker without
 # restarting containers
 # https://docs.docker.com/config/containers/live-restore/
-cat >/etc/docker/damon.json <<EOF
+cat >/etc/docker/daemon.json <<EOF
 {
   "live-restore": true
 }

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Log executed commands so it's easier to debug script failures
+set -x
+
 echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
 
 # Update ECS agent

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
 
+# Update ECS agent
+yum update -y ecs-init
+
 # Setup memory and disk usage monitoring
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html
 

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
 
+
 # Update ECS agent
 yum update -y ecs-init
+
+# Install security updates
+yum update -y --security
 
 # Setup memory and disk usage monitoring
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html


### PR DESCRIPTION
- [x] Install security updates at instance startup and daily using yum-cron
- [x] Update ECS agent at instance startup and daily (using cron.daily)
- [x] Enable [docker daemon live restore](https://docs.docker.com/config/containers/live-restore/)

Known issues:
- fixed in 756c679: the ECS agent might not be fully up to date initially, for some reason `docker pull amazon/amazon-ecs-agent:latest` doesn't seem to work as expected when run from the user data script. When you ssh into an instance and run `docker pull` it will say that there was a newer image, even though it should have already been pulled. 

Closes #52 
Closes #53 