### PR TITLE
refactor(ecs/host_group): switch from launch configuration to a launch template

### DIFF
--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -36,6 +36,26 @@ data "template_file" "user_data" {
   }
 }
 
+# No longer used, left to make sure terraform doesn't try to destroy this
+# before switching autoscaling group to the launch template,
+# will be removed in another PR
+resource "aws_launch_configuration" "hosts" {
+  count = var.create ? 1 : 0
+
+  name_prefix          = "${local.full_name}-"
+  image_id             = data.aws_ami.ecs_amazon_linux[0].id
+  instance_type        = var.instance_type
+  security_groups      = [var.security_group_id]
+  iam_instance_profile = var.instance_profile
+  user_data            = data.template_file.user_data[0].rendered
+  key_name             = var.bastion_key_name
+  enable_monitoring    = var.detailed_monitoring
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_launch_template" "hosts" {
   count = var.create ? 1 : 0
 


### PR DESCRIPTION
- [x] Switched from using a launch configuration to a launch template, so we can add #42 

To do:
- remove the launch configuration in a separate PR, for some reason terraform tries to remove it before switching the ASG to the launch template which results in a failure

https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html