### PR TITLE
feat(ecs/host_group)!: added cpu_credits variable

### DIFF
--- a/ecs/host_group/README.md
+++ b/ecs/host_group/README.md
@@ -26,6 +26,10 @@ Creates an auto-scaling group of EC2 instances which will join the given ECS clu
 
     Name of the ECS cluster to attach to
 
+* `cpu_credits` (`string`, default: `"standard"`)
+
+    The credit option for CPU usage. Can be 'standard' or 'unlimited'.
+
 * `create` (`bool`, default: `true`)
 
     Should resources be created

--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -73,6 +73,10 @@ resource "aws_launch_template" "hosts" {
   monitoring {
     enabled = var.detailed_monitoring
   }
+
+  credit_specification {
+    cpu_credits = var.cpu_credits
+  }
 }
 
 resource "aws_autoscaling_group" "hosts" {

--- a/ecs/host_group/variables.tf
+++ b/ecs/host_group/variables.tf
@@ -85,3 +85,8 @@ variable "detailed_monitoring" {
   default     = true
 }
 
+variable "cpu_credits" {
+  description = "The credit option for CPU usage. Can be 'standard' or 'unlimited'."
+  type        = string
+  default     = "standard"
+}


### PR DESCRIPTION
- [x] Added `cpu_credits` variable which defaults to `standard` for more predictable billing

**BREAKING CHANGES**: 
- Launch template now defaults to `standard` cpu credits regardless of instance_type. If you were using t3* instances this used to be `unlimited`, so you might need to either add `cpu_credits = "unlimited"` or update your instances

Closes #42 

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-credits-baseline-concepts.html