### PR TITLE
fix(ecs/host_group)!: reverted cpu credits defaults

### DIFF
--- a/ecs/host_group/README.md
+++ b/ecs/host_group/README.md
@@ -26,7 +26,7 @@ Creates an auto-scaling group of EC2 instances which will join the given ECS clu
 
     Name of the ECS cluster to attach to
 
-* `cpu_credits` (`string`, default: `"standard"`)
+* `cpu_credits` (`string`, default: `null`)
 
     The credit option for CPU usage. Can be 'standard' or 'unlimited'.
 

--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -105,7 +105,7 @@ resource "aws_autoscaling_group" "hosts" {
 
   launch_template {
     id      = aws_launch_template.hosts[0].id
-    version = "$Latest"
+    version = aws_launch_template.hosts[0].latest_version
   }
 
   dynamic "tag" {

--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -74,8 +74,11 @@ resource "aws_launch_template" "hosts" {
     enabled = var.detailed_monitoring
   }
 
-  credit_specification {
-    cpu_credits = var.cpu_credits
+  dynamic "credit_specification" {
+    for_each = toset(var.cpu_credits != null ? ["credit_specification"] : [])
+    content {
+      cpu_credits = var.cpu_credits
+    }
   }
 }
 

--- a/ecs/host_group/variables.tf
+++ b/ecs/host_group/variables.tf
@@ -88,5 +88,5 @@ variable "detailed_monitoring" {
 variable "cpu_credits" {
   description = "The credit option for CPU usage. Can be 'standard' or 'unlimited'."
   type        = string
-  default     = "standard"
+  default     = null
 }


### PR DESCRIPTION
- [x] reverted `cpu_credits` default value back to AWS defaults, which is `unlimited` for `t3*` instances and `standard` for everything else
- [x] made the launch template version explicit in the autoscaling group

**BREAKING CHANGES**:
- reverted `cpu_credits` default value back to AWS default, which reverts the breaking change from #57 