### PR TITLE
fix(ecs/network): SSM agents restart fails with "You must specify a region"

### DIFF
--- a/ecs/network/main.tf
+++ b/ecs/network/main.tf
@@ -365,7 +365,7 @@ resource "null_resource" "ssm_restart_after_nat_change" {
     # Restart SSM agents of instances within the private subnet
     command = <<EOT
       set -e
-      export AWS_REGION=${local.aws_region}
+      export AWS_DEFAULT_REGION=${local.aws_region}
       subnet_id=${aws_subnet.private[count.index].id}
 
       echo "Fetching running EC2 instance ids in subnet $subnet_id"


### PR DESCRIPTION
AWS CLI requires `AWS_DEFAULT_REGION` environment variable and ignores `AWS_REGION`
Bug was introduced in b2b6b8574ec9036cd03c150a25b75fb320f27abe