### PR TITLE
fix(ecs/host_group): stopped containers overflow

### DIFF
--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -5,6 +5,11 @@ set -x
 
 cat >/etc/ecs/ecs.config <<EOF
 ECS_CLUSTER=${cluster_name}
+
+# Speed up stopped container removal, defaults to 3h.
+# Long wait duration can lead to the disk being filled up with instances
+# of a broken container that gets restarted over and over again.
+ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=5m
 EOF
 
 # Update ECS agent

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -3,7 +3,9 @@
 # Log executed commands so it's easier to debug script failures
 set -x
 
-echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
+cat >/etc/ecs/ecs.config <<EOF
+ECS_CLUSTER=${cluster_name}
+EOF
 
 # Update ECS agent
 yum update -y ecs-init


### PR DESCRIPTION
By default ECS agent removes stopped containers after 3 hours, which is nice for debugging, but can also kill an instance if a task creates some files, fails and is restarted over and over, filling up the whole disk.

Lowered the wait time to 5 minutes to minimize the chance of that happening.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html