### PR TITLE
feat(ecs/host_group): enabled instance user data customization

### DIFF
--- a/ecs/host_group/README.md
+++ b/ecs/host_group/README.md
@@ -34,6 +34,10 @@ Creates an auto-scaling group of EC2 instances which will join the given ECS clu
 
     Whether to enable detailed monitoring on EC2 instances
 
+* `ecs_agent_config` (`string`, default: `""`)
+
+    ECS agent configuration to append to the default one
+
 * `environment` (`string`, required)
 
     Kebab-cased environment name, eg. development, staging, production.

--- a/ecs/host_group/README.md
+++ b/ecs/host_group/README.md
@@ -78,6 +78,10 @@ Creates an auto-scaling group of EC2 instances which will join the given ECS clu
 
     Tags to add to resources that support them
 
+* `user_data` (`string`, default: `""`)
+
+    Bash script to append to the default user data script
+
 
 
 ## Outputs

--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -34,6 +34,7 @@ data "template_file" "user_data" {
     cluster_name        = var.cluster_name
     detailed_monitoring = var.detailed_monitoring
     user_data           = var.user_data
+    ecs_agent_config    = var.ecs_agent_config
   }
 }
 

--- a/ecs/host_group/main.tf
+++ b/ecs/host_group/main.tf
@@ -33,6 +33,7 @@ data "template_file" "user_data" {
   vars = {
     cluster_name        = var.cluster_name
     detailed_monitoring = var.detailed_monitoring
+    user_data           = var.user_data
   }
 }
 

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -10,6 +10,8 @@ ECS_CLUSTER=${cluster_name}
 # Long wait duration can lead to the disk being filled up with instances
 # of a broken container that gets restarted over and over again.
 ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=5m
+
+${ecs_agent_config}
 EOF
 
 # Update ECS agent

--- a/ecs/host_group/templates/user_data.sh
+++ b/ecs/host_group/templates/user_data.sh
@@ -100,3 +100,5 @@ cat >/etc/cron.d/ec2_metrics <<EOF
 *${detailed_monitoring ? "" : "/5"} * * * * ec2-user /opt/aws-scripts-mon/mon-put-instance-data.pl --from-cron --auto-scaling --mem-util --mem-used --mem-avail --swap-util --swap-used
 *${detailed_monitoring ? "" : "/5"} * * * * ec2-user /opt/aws-scripts-mon/mon-put-instance-data.pl --from-cron --auto-scaling --disk-path=/ --disk-space-util --disk-space-used --disk-space-avail
 EOF
+
+${user_data}

--- a/ecs/host_group/variables.tf
+++ b/ecs/host_group/variables.tf
@@ -85,3 +85,9 @@ variable "cpu_credits" {
   type        = string
   default     = null
 }
+
+variable "user_data" {
+  description = "Bash script to append to the default user data script"
+  type        = string
+  default     = ""
+}

--- a/ecs/host_group/variables.tf
+++ b/ecs/host_group/variables.tf
@@ -91,3 +91,9 @@ variable "user_data" {
   type        = string
   default     = ""
 }
+
+variable "ecs_agent_config" {
+  description = "ECS agent configuration to append to the default one"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- [x] added `user_data` variable for appending custom bash commands to the default script
- [x] added `ecs_agent_config` variable for appending custom [ECS agent configuration](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)