### PR TITLE
feat(ecs/host_group): cloudwatch metrics and dashboard widgets

### DIFF
--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -111,6 +111,8 @@ module "dashboard" {
     module.hosts.widgets.root_fs_free,
     module.hosts.widgets.fs_io_bytes,
     module.hosts.widgets.fs_io_ops,
+    module.hosts.widgets.network_bytes,
+    module.hosts.widgets.network_packets,
   ]
 }
 

--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -103,6 +103,7 @@ module "dashboard" {
   widgets = [
     module.hosts.widgets.instance_scaling,
     module.hosts.widgets.instance_states,
+    module.hosts.widgets.memory_utilization,
   ]
 }
 

--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -109,6 +109,8 @@ module "dashboard" {
     module.hosts.widgets.cpu_credit_usage,
     module.hosts.widgets.root_fs_utilization,
     module.hosts.widgets.root_fs_free,
+    module.hosts.widgets.fs_io_bytes,
+    module.hosts.widgets.fs_io_ops,
   ]
 }
 

--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -105,6 +105,8 @@ module "dashboard" {
     module.hosts.widgets.instance_states,
     module.hosts.widgets.memory_utilization,
     module.hosts.widgets.cpu_utilization,
+    module.hosts.widgets.cpu_credit_balance,
+    module.hosts.widgets.cpu_credit_usage,
   ]
 }
 

--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -96,6 +96,20 @@ module "web" {
   healthcheck_path = "/"
 }
 
+module "dashboard" {
+  source = "./../../cloudwatch/dashboard"
+
+  name = "terraform-ecs-example"
+  widgets = [
+    module.hosts.widgets.instance_scaling,
+    module.hosts.widgets.instance_states,
+  ]
+}
+
 output "hosts_id" {
   value = module.hosts.id
+}
+
+output "dashboard_url" {
+  value = module.dashboard.url
 }

--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -107,6 +107,8 @@ module "dashboard" {
     module.hosts.widgets.cpu_utilization,
     module.hosts.widgets.cpu_credit_balance,
     module.hosts.widgets.cpu_credit_usage,
+    module.hosts.widgets.root_fs_utilization,
+    module.hosts.widgets.root_fs_free,
   ]
 }
 

--- a/ecs/example/main.tf
+++ b/ecs/example/main.tf
@@ -104,6 +104,7 @@ module "dashboard" {
     module.hosts.widgets.instance_scaling,
     module.hosts.widgets.instance_states,
     module.hosts.widgets.memory_utilization,
+    module.hosts.widgets.cpu_utilization,
   ]
 }
 

--- a/ecs/host_group/README.md
+++ b/ecs/host_group/README.md
@@ -97,3 +97,11 @@ Creates an auto-scaling group of EC2 instances which will join the given ECS clu
 * `id`
 
     Autoscaling group id
+
+* `metrics`
+
+    Cloudwatch metrics, see [metrics.tf](./metrics.tf)
+
+* `widgets`
+
+    Cloudwatch dashboard widgets, see [widgets.tf](./widgets.tf)

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -1,0 +1,5 @@
+locals {
+  metrics = {
+
+  }
+}

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -382,7 +382,7 @@ locals {
     }
     bytes_sent = {
       name  = "NetworkOut"
-      label = "Received bytes"
+      label = "Sent bytes"
       color = local.io_colors.write
       stat  = "Sum"
     }
@@ -394,7 +394,7 @@ locals {
     }
     packets_sent = {
       name  = "NetworkPacketsOut"
-      label = "Received packets"
+      label = "Sent packets"
       color = local.io_colors.write
       stat  = "Sum"
     }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -11,6 +11,16 @@ locals {
     pending_instances     = module.metric_pending_instances
     standby_instances     = module.metric_standby_instances
     terminating_instances = module.metric_terminating_instances
+
+    # memory utilization
+    memory_utilization         = module.metric_memory_utilization
+    min_memory_utilization     = module.metric_min_memory_utilization
+    average_memory_utilization = module.metric_average_memory_utilization
+    max_memory_utilization     = module.metric_max_memory_utilization
+    swap_utilization           = module.metric_swap_utilization
+    min_swap_utilization       = module.metric_min_swap_utilization
+    average_swap_utilization   = module.metric_average_swap_utilization
+    max_swap_utilization       = module.metric_max_swap_utilization
   }
 }
 
@@ -119,4 +129,98 @@ module "metric_terminating_instances" {
   color      = local.colors.red
   period     = 60
   stat       = "Average"
+}
+
+module "metric_memory_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "MemoryUtilization"
+  label      = "Memory utilization"
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_min_memory_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "MemoryUtilization"
+  label      = "Minimum memory utilization"
+  color      = local.colors.light_orange
+  stat       = "Minimum"
+  period     = 60
+}
+
+module "metric_average_memory_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "MemoryUtilization"
+  label      = "Average memory utilization"
+  color      = local.colors.orange
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_max_memory_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "MemoryUtilization"
+  label      = "Maximum memory utilization"
+  color      = local.colors.red
+  stat       = "Maximum"
+  period     = 60
+}
+
+module "metric_swap_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "SwapUtilization"
+  label      = "Swap utilization"
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_min_swap_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "SwapUtilization"
+  label      = "Minimum swap utilization"
+  color      = local.colors.light_pink
+  stat       = "Minimum"
+  period     = 60
+}
+
+module "metric_average_swap_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "SwapUtilization"
+  label      = "Average swap utilization"
+  color      = local.colors.pink
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_max_swap_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_dimensions
+  name       = "SwapUtilization"
+  label      = "Maximum swap utilization"
+  color      = local.colors.purple
+  stat       = "Maximum"
+  period     = 60
 }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -26,6 +26,12 @@ locals {
     min_cpu_utilization     = module.metric_min_cpu_utilization
     average_cpu_utilization = module.metric_average_cpu_utilization
     max_cpu_utilization     = module.metric_max_cpu_utilization
+
+    # cpu credit balance
+    cpu_credit_usage            = module.metric_cpu_credit_usage
+    cpu_credit_balance          = module.metric_cpu_credit_balance
+    cpu_surplus_credit_balance  = module.metric_cpu_surplus_credit_balance
+    cpu_surplus_credits_charged = module.metric_cpu_surplus_credits_charged
   }
 }
 
@@ -264,4 +270,51 @@ module "metric_max_cpu_utilization" {
   color      = local.colors.red
   stat       = "Maximum"
   period     = 60
+}
+
+module "metric_cpu_credit_usage" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "CPUCreditUsage"
+  label      = "CPU credit usage"
+  stat       = "Sum"
+  period     = 300
+}
+
+module "metric_cpu_credit_balance" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "CPUCreditBalance"
+  label      = "CPU credit balance"
+  color      = local.colors.green
+  stat       = "Average"
+  period     = 300
+}
+
+module "metric_cpu_surplus_credit_balance" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "CPUSurplusCreditBalance"
+  label      = "CPU surplus credit balance"
+  color      = local.colors.orange
+  stat       = "Average"
+  period     = 300
+}
+
+module "metric_cpu_surplus_credits_charged" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "CPUSurplusCreditsCharged"
+  label      = "CPU surplus credits charged"
+  color      = local.colors.red
+  stat       = "Average"
+  period     = 300
 }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -40,6 +40,16 @@ locals {
     min_root_fs_free            = module.metric_min_root_fs_free
     average_root_fs_free        = module.metric_average_root_fs_free
     max_root_fs_free            = module.metric_max_root_fs_free
+
+    # filesystem reads/writes
+    fs_bytes_read            = module.metric_fs_bytes_read
+    fs_reads                 = module.metric_fs_reads
+    fs_bytes_written         = module.metric_fs_bytes_written
+    fs_writes                = module.metric_fs_writes
+    average_fs_bytes_read    = module.metric_average_fs_bytes_read
+    average_fs_reads         = module.metric_average_fs_reads
+    average_fs_bytes_written = module.metric_average_fs_bytes_written
+    average_fs_writes        = module.metric_average_fs_writes
   }
 }
 
@@ -403,5 +413,108 @@ module "metric_max_root_fs_free" {
   label      = "Maximum root filesystem free space"
   color      = local.colors.light_orange
   stat       = "Maximum"
+  period     = 60
+}
+
+locals {
+  fs_colors = {
+    read  = local.colors.green
+    write = local.colors.orange
+  }
+}
+
+module "metric_fs_bytes_read" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSReadBytes"
+  label      = "Bytes read"
+  color      = local.fs_colors.read
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_fs_bytes_read" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSReadBytes"
+  label      = "Average bytes read"
+  color      = local.fs_colors.read
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_fs_reads" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSReadOps"
+  label      = "Reads"
+  color      = local.fs_colors.read
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_fs_reads" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSReadOps"
+  label      = "Average reads"
+  color      = local.fs_colors.read
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_fs_bytes_written" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSWriteBytes"
+  label      = "Bytes written"
+  color      = local.fs_colors.write
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_fs_bytes_written" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSWriteBytes"
+  label      = "Average bytes written"
+  color      = local.fs_colors.write
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_fs_writes" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSWriteOps"
+  label      = "Writes"
+  color      = local.fs_colors.write
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_fs_writes" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "EBSWriteOps"
+  label      = "Average writes"
+  color      = local.fs_colors.write
+  stat       = "Average"
   period     = 60
 }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -20,124 +20,103 @@ module "cloudwatch_consts" {
 
 locals {
   colors = module.cloudwatch_consts.colors
+  group_dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
 }
 
 module "metric_min_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupMinSize"
-  label     = "Minimum instances"
-  color     = local.colors.light_grey
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupMinSize"
+  label      = "Minimum instances"
+  color      = local.colors.light_grey
+  period     = 60
+  stat       = "Average"
 }
 
 module "metric_max_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupMaxSize"
-  label     = "Maximum instances"
-  color     = local.colors.light_grey
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupMaxSize"
+  label      = "Maximum instances"
+  color      = local.colors.light_grey
+  period     = 60
+  stat       = "Average"
 }
 
 module "metric_desired_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupDesiredCapacity"
-  label     = "Desired instances"
-  color     = local.colors.grey
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupDesiredCapacity"
+  label      = "Desired instances"
+  color      = local.colors.grey
+  period     = 60
+  stat       = "Average"
 }
 
 module "metric_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupTotalInstances"
-  label     = "Total instances"
-  color     = local.colors.green
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupTotalInstances"
+  label      = "Total instances"
+  color      = local.colors.green
+  period     = 60
+  stat       = "Average"
 }
 
 module "metric_in_service_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupInServiceInstances"
-  label     = "In service instances"
-  color     = local.colors.green
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupInServiceInstances"
+  label      = "In service instances"
+  color      = local.colors.green
+  period     = 60
+  stat       = "Average"
 }
 
 module "metric_pending_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupPendingInstances"
-  label     = "Pending instances"
-  color     = local.colors.orange
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupPendingInstances"
+  label      = "Pending instances"
+  color      = local.colors.orange
+  period     = 60
+  stat       = "Average"
 }
 
 module "metric_standby_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupStandbyInstances"
-  label     = "Standby instances"
-  color     = local.colors.light_green
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupStandbyInstances"
+  label      = "Standby instances"
+  color      = local.colors.light_green
+  period     = 60
+  stat       = "Average"
 }
 
 module "metric_terminating_instances" {
   source = "./../../cloudwatch/metric"
 
-  namespace = "AWS/AutoScaling"
-  name      = "GroupTerminatingInstances"
-  label     = "Terminating instances"
-  color     = local.colors.red
-  period    = 60
-  stat      = "Average"
-
-  dimensions = {
-    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
-  }
+  namespace  = "AWS/AutoScaling"
+  dimensions = local.group_dimensions
+  name       = "GroupTerminatingInstances"
+  label      = "Terminating instances"
+  color      = local.colors.red
+  period     = 60
+  stat       = "Average"
 }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -50,6 +50,16 @@ locals {
     average_fs_reads         = module.metric_average_fs_reads
     average_fs_bytes_written = module.metric_average_fs_bytes_written
     average_fs_writes        = module.metric_average_fs_writes
+
+    # network in/out
+    bytes_received           = module.metric_bytes_received
+    packets_received         = module.metric_packets_received
+    bytes_sent               = module.metric_bytes_sent
+    packets_sent             = module.metric_packets_sent
+    average_bytes_received   = module.metric_average_bytes_received
+    average_packets_received = module.metric_average_packets_received
+    average_bytes_sent       = module.metric_average_bytes_sent
+    average_packets_sent     = module.metric_average_packets_sent
   }
 }
 
@@ -514,6 +524,102 @@ module "metric_average_fs_writes" {
   dimensions = local.group_dimensions
   name       = "EBSWriteOps"
   label      = "Average writes"
+  color      = local.fs_colors.write
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_bytes_received" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkIn"
+  label      = "Received bytes"
+  color      = local.fs_colors.read
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_bytes_received" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkIn"
+  label      = "Average received bytes"
+  color      = local.fs_colors.read
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_packets_received" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkPacketsIn"
+  label      = "Received packets"
+  color      = local.fs_colors.read
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_packets_received" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkPacketsIn"
+  label      = "Average received packets"
+  color      = local.fs_colors.read
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_bytes_sent" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkOut"
+  label      = "Received bytes"
+  color      = local.fs_colors.write
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_bytes_sent" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkOut"
+  label      = "Average sent bytes"
+  color      = local.fs_colors.write
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_packets_sent" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkPacketsOut"
+  label      = "Received packets"
+  color      = local.fs_colors.write
+  stat       = "Sum"
+  period     = 60
+}
+
+module "metric_average_packets_sent" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "NetworkPacketsOut"
+  label      = "Average sent packets"
   color      = local.fs_colors.write
   stat       = "Average"
   period     = 60

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -21,6 +21,11 @@ locals {
     min_swap_utilization       = module.metric_min_swap_utilization
     average_swap_utilization   = module.metric_average_swap_utilization
     max_swap_utilization       = module.metric_max_swap_utilization
+
+    # cpu utilization
+    min_cpu_utilization     = module.metric_min_cpu_utilization
+    average_cpu_utilization = module.metric_average_cpu_utilization
+    max_cpu_utilization     = module.metric_max_cpu_utilization
   }
 }
 
@@ -221,6 +226,42 @@ module "metric_max_swap_utilization" {
   name       = "SwapUtilization"
   label      = "Maximum swap utilization"
   color      = local.colors.purple
+  stat       = "Maximum"
+  period     = 60
+}
+
+module "metric_min_cpu_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "CPUUtilization"
+  label      = "Minimum CPU utilization"
+  color      = local.colors.light_orange
+  stat       = "Minimum"
+  period     = 60
+}
+
+module "metric_average_cpu_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "CPUUtilization"
+  label      = "Average CPU utilization"
+  color      = local.colors.orange
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_max_cpu_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "AWS/EC2"
+  dimensions = local.group_dimensions
+  name       = "CPUUtilization"
+  label      = "Maximum CPU utilization"
+  color      = local.colors.red
   stat       = "Maximum"
   period     = 60
 }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -32,6 +32,14 @@ locals {
     cpu_credit_balance          = module.metric_cpu_credit_balance
     cpu_surplus_credit_balance  = module.metric_cpu_surplus_credit_balance
     cpu_surplus_credits_charged = module.metric_cpu_surplus_credits_charged
+
+    # filesystem utilization
+    min_root_fs_utilization     = module.metric_min_root_fs_utilization
+    average_root_fs_utilization = module.metric_average_root_fs_utilization
+    max_root_fs_utilization     = module.metric_max_root_fs_utilization
+    min_root_fs_free            = module.metric_min_root_fs_free
+    average_root_fs_free        = module.metric_average_root_fs_free
+    max_root_fs_free            = module.metric_max_root_fs_free
   }
 }
 
@@ -317,4 +325,83 @@ module "metric_cpu_surplus_credits_charged" {
   color      = local.colors.red
   stat       = "Average"
   period     = 300
+}
+
+locals {
+  group_root_fs_dimensions = merge(local.group_dimensions, {
+    MountPath  = "/"
+    Filesystem = "/dev/nvme0n1p1"
+  })
+}
+
+module "metric_min_root_fs_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_root_fs_dimensions
+  name       = "DiskSpaceUtilization"
+  label      = "Minimum root filesystem utilization"
+  color      = local.colors.light_orange
+  stat       = "Minimum"
+  period     = 60
+}
+
+module "metric_average_root_fs_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_root_fs_dimensions
+  name       = "DiskSpaceUtilization"
+  label      = "Average root filesystem utilization"
+  color      = local.colors.orange
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_max_root_fs_utilization" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_root_fs_dimensions
+  name       = "DiskSpaceUtilization"
+  label      = "Maximum root filesystem utilization"
+  color      = local.colors.red
+  stat       = "Maximum"
+  period     = 60
+}
+
+module "metric_min_root_fs_free" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_root_fs_dimensions
+  name       = "DiskSpaceAvailable"
+  label      = "Minimum root filesystem free space"
+  color      = local.colors.red
+  stat       = "Minimum"
+  period     = 60
+}
+
+module "metric_average_root_fs_free" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_root_fs_dimensions
+  name       = "DiskSpaceAvailable"
+  label      = "Average root filesystem free space"
+  color      = local.colors.orange
+  stat       = "Average"
+  period     = 60
+}
+
+module "metric_max_root_fs_free" {
+  source = "./../../cloudwatch/metric"
+
+  namespace  = "System/Linux"
+  dimensions = local.group_root_fs_dimensions
+  name       = "DiskSpaceAvailable"
+  label      = "Maximum root filesystem free space"
+  color      = local.colors.light_orange
+  stat       = "Maximum"
+  period     = 60
 }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -36,6 +36,7 @@ module "metric_min_instances" {
     AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }
+
 module "metric_max_instances" {
   source = "./../../cloudwatch/metric"
 
@@ -50,6 +51,7 @@ module "metric_max_instances" {
     AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }
+
 module "metric_desired_instances" {
   source = "./../../cloudwatch/metric"
 
@@ -64,6 +66,7 @@ module "metric_desired_instances" {
     AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }
+
 module "metric_instances" {
   source = "./../../cloudwatch/metric"
 
@@ -78,6 +81,7 @@ module "metric_instances" {
     AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }
+
 module "metric_in_service_instances" {
   source = "./../../cloudwatch/metric"
 
@@ -92,6 +96,7 @@ module "metric_in_service_instances" {
     AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }
+
 module "metric_pending_instances" {
   source = "./../../cloudwatch/metric"
 
@@ -106,6 +111,7 @@ module "metric_pending_instances" {
     AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }
+
 module "metric_standby_instances" {
   source = "./../../cloudwatch/metric"
 
@@ -120,6 +126,7 @@ module "metric_standby_instances" {
     AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }
+
 module "metric_terminating_instances" {
   source = "./../../cloudwatch/metric"
 

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -1,5 +1,136 @@
 locals {
   metrics = {
+    # scaling inputs
+    min_instances     = module.metric_min_instances
+    max_instances     = module.metric_max_instances
+    desired_instances = module.metric_desired_instances
 
+    # instance counts by status
+    instances             = module.metric_instances
+    in_service_instances  = module.metric_in_service_instances
+    pending_instances     = module.metric_pending_instances
+    standby_instances     = module.metric_standby_instances
+    terminating_instances = module.metric_terminating_instances
+  }
+}
+
+module "cloudwatch_consts" {
+  source = "./../../cloudwatch/consts"
+}
+
+locals {
+  colors = module.cloudwatch_consts.colors
+}
+
+module "metric_min_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupMinSize"
+  label     = "Minimum instances"
+  color     = local.colors.light_grey
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
+}
+module "metric_max_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupMaxSize"
+  label     = "Maximum instances"
+  color     = local.colors.light_grey
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
+}
+module "metric_desired_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupDesiredCapacity"
+  label     = "Desired instances"
+  color     = local.colors.grey
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
+}
+module "metric_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupTotalInstances"
+  label     = "Total instances"
+  color     = local.colors.green
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
+}
+module "metric_in_service_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupInServiceInstances"
+  label     = "In service instances"
+  color     = local.colors.green
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
+}
+module "metric_pending_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupPendingInstances"
+  label     = "Pending instances"
+  color     = local.colors.orange
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
+}
+module "metric_standby_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupStandbyInstances"
+  label     = "Standby instances"
+  color     = local.colors.light_green
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
+  }
+}
+module "metric_terminating_instances" {
+  source = "./../../cloudwatch/metric"
+
+  namespace = "AWS/AutoScaling"
+  name      = "GroupTerminatingInstances"
+  label     = "Terminating instances"
+  color     = local.colors.red
+  period    = 60
+  stat      = "Average"
+
+  dimensions = {
+    AutoScalingGroupName = var.create ? aws_autoscaling_group.hosts[0].name : ""
   }
 }

--- a/ecs/host_group/metrics.tf
+++ b/ecs/host_group/metrics.tf
@@ -1,65 +1,65 @@
 locals {
   metrics = {
     # scaling inputs
-    min_instances     = module.metric_min_instances
-    max_instances     = module.metric_max_instances
-    desired_instances = module.metric_desired_instances
+    min_instances     = module.metrics_instance_count.out_map.min
+    max_instances     = module.metrics_instance_count.out_map.max
+    desired_instances = module.metrics_instance_count.out_map.desired
 
     # instance counts by status
-    instances             = module.metric_instances
-    in_service_instances  = module.metric_in_service_instances
-    pending_instances     = module.metric_pending_instances
-    standby_instances     = module.metric_standby_instances
-    terminating_instances = module.metric_terminating_instances
+    instances             = module.metrics_instance_count.out_map.total
+    in_service_instances  = module.metrics_instance_count.out_map.in_service
+    pending_instances     = module.metrics_instance_count.out_map.pending
+    standby_instances     = module.metrics_instance_count.out_map.standby
+    terminating_instances = module.metrics_instance_count.out_map.terminating
 
     # memory utilization
     memory_utilization         = module.metric_memory_utilization
-    min_memory_utilization     = module.metric_min_memory_utilization
-    average_memory_utilization = module.metric_average_memory_utilization
-    max_memory_utilization     = module.metric_max_memory_utilization
+    min_memory_utilization     = module.metrics_memory_utilization.out_map.min
+    average_memory_utilization = module.metrics_memory_utilization.out_map.average
+    max_memory_utilization     = module.metrics_memory_utilization.out_map.max
     swap_utilization           = module.metric_swap_utilization
-    min_swap_utilization       = module.metric_min_swap_utilization
-    average_swap_utilization   = module.metric_average_swap_utilization
-    max_swap_utilization       = module.metric_max_swap_utilization
+    min_swap_utilization       = module.metrics_swap_utilization.out_map.min
+    average_swap_utilization   = module.metrics_swap_utilization.out_map.average
+    max_swap_utilization       = module.metrics_swap_utilization.out_map.max
 
     # cpu utilization
-    min_cpu_utilization     = module.metric_min_cpu_utilization
-    average_cpu_utilization = module.metric_average_cpu_utilization
-    max_cpu_utilization     = module.metric_max_cpu_utilization
+    min_cpu_utilization     = module.metrics_cpu_utilization.out_map.min
+    average_cpu_utilization = module.metrics_cpu_utilization.out_map.average
+    max_cpu_utilization     = module.metrics_cpu_utilization.out_map.max
 
     # cpu credit balance
     cpu_credit_usage            = module.metric_cpu_credit_usage
-    cpu_credit_balance          = module.metric_cpu_credit_balance
-    cpu_surplus_credit_balance  = module.metric_cpu_surplus_credit_balance
-    cpu_surplus_credits_charged = module.metric_cpu_surplus_credits_charged
+    cpu_credit_balance          = module.metrics_cpu_credit_balance.out_map.balance
+    cpu_surplus_credit_balance  = module.metrics_cpu_credit_balance.out_map.surplus
+    cpu_surplus_credits_charged = module.metrics_cpu_credit_balance.out_map.surplus_charged
 
     # filesystem utilization
-    min_root_fs_utilization     = module.metric_min_root_fs_utilization
-    average_root_fs_utilization = module.metric_average_root_fs_utilization
-    max_root_fs_utilization     = module.metric_max_root_fs_utilization
-    min_root_fs_free            = module.metric_min_root_fs_free
-    average_root_fs_free        = module.metric_average_root_fs_free
-    max_root_fs_free            = module.metric_max_root_fs_free
+    min_root_fs_utilization     = module.metrics_root_fs_utilization.out_map.min
+    average_root_fs_utilization = module.metrics_root_fs_utilization.out_map.average
+    max_root_fs_utilization     = module.metrics_root_fs_utilization.out_map.max
+    min_root_fs_free            = module.metrics_root_fs_free.out_map.min
+    average_root_fs_free        = module.metrics_root_fs_free.out_map.average
+    max_root_fs_free            = module.metrics_root_fs_free.out_map.max
 
     # filesystem reads/writes
-    fs_bytes_read            = module.metric_fs_bytes_read
-    fs_reads                 = module.metric_fs_reads
-    fs_bytes_written         = module.metric_fs_bytes_written
-    fs_writes                = module.metric_fs_writes
-    average_fs_bytes_read    = module.metric_average_fs_bytes_read
-    average_fs_reads         = module.metric_average_fs_reads
-    average_fs_bytes_written = module.metric_average_fs_bytes_written
-    average_fs_writes        = module.metric_average_fs_writes
+    fs_bytes_read            = module.metrics_io.out_map.fs_bytes_read
+    fs_reads                 = module.metrics_io.out_map.fs_reads
+    fs_bytes_written         = module.metrics_io.out_map.fs_bytes_written
+    fs_writes                = module.metrics_io.out_map.fs_writes
+    average_fs_bytes_read    = module.metrics_io.out_map.average_fs_bytes_read
+    average_fs_reads         = module.metrics_io.out_map.average_fs_reads
+    average_fs_bytes_written = module.metrics_io.out_map.average_fs_bytes_written
+    average_fs_writes        = module.metrics_io.out_map.average_fs_writes
 
     # network in/out
-    bytes_received           = module.metric_bytes_received
-    packets_received         = module.metric_packets_received
-    bytes_sent               = module.metric_bytes_sent
-    packets_sent             = module.metric_packets_sent
-    average_bytes_received   = module.metric_average_bytes_received
-    average_packets_received = module.metric_average_packets_received
-    average_bytes_sent       = module.metric_average_bytes_sent
-    average_packets_sent     = module.metric_average_packets_sent
+    bytes_received           = module.metrics_io.out_map.bytes_received
+    packets_received         = module.metrics_io.out_map.packets_received
+    bytes_sent               = module.metrics_io.out_map.bytes_sent
+    packets_sent             = module.metrics_io.out_map.packets_sent
+    average_bytes_received   = module.metrics_io.out_map.average_bytes_received
+    average_packets_received = module.metrics_io.out_map.average_packets_received
+    average_bytes_sent       = module.metrics_io.out_map.average_bytes_sent
+    average_packets_sent     = module.metrics_io.out_map.average_packets_sent
   }
 }
 
@@ -74,100 +74,71 @@ locals {
   }
 }
 
-module "metric_min_instances" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupMinSize"
-  label      = "Minimum instances"
-  color      = local.colors.light_grey
-  period     = 60
-  stat       = "Average"
+locals {
+  metrics_instance_count = {
+    min = {
+      name  = "GroupMinSize"
+      label = "Minimum instances"
+      color = local.colors.light_grey
+    }
+    max = {
+      name  = "GroupMaxSize"
+      label = "Maximum instances"
+      color = local.colors.light_grey
+    }
+    desired = {
+      name  = "GroupDesiredCapacity",
+      label = "Desired instances",
+      color = local.colors.grey
+    }
+    total = {
+      name  = "GroupTotalInstances",
+      label = "Total instances",
+      color = local.colors.green
+    }
+    pending = {
+      name  = "GroupPendingInstances"
+      label = "Pending instances"
+      color = local.colors.orange
+    }
+    standby = {
+      name  = "GroupStandbyInstances"
+      label = "Standby instances"
+      color = local.colors.light_green
+    }
+    in_service = {
+      name  = "GroupInServiceInstances"
+      label = "In service instances"
+      color = local.colors.green
+    }
+    terminating = {
+      name  = "GroupTerminatingInstances"
+      label = "Terminating instances"
+      color = local.colors.red
+    }
+  }
 }
 
-module "metric_max_instances" {
-  source = "./../../cloudwatch/metric"
+module "metrics_instance_count" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupMaxSize"
-  label      = "Maximum instances"
-  color      = local.colors.light_grey
-  period     = 60
-  stat       = "Average"
+  vars_map = { for k, variant in local.metrics_instance_count : k => {
+    namespace  = "AWS/AutoScaling"
+    dimensions = local.group_dimensions
+    name       = variant.name
+    label      = variant.label
+    color      = variant.color
+    period     = 60
+    stat       = "Average"
+  } }
 }
 
-module "metric_desired_instances" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupDesiredCapacity"
-  label      = "Desired instances"
-  color      = local.colors.grey
-  period     = 60
-  stat       = "Average"
-}
-
-module "metric_instances" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupTotalInstances"
-  label      = "Total instances"
-  color      = local.colors.green
-  period     = 60
-  stat       = "Average"
-}
-
-module "metric_in_service_instances" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupInServiceInstances"
-  label      = "In service instances"
-  color      = local.colors.green
-  period     = 60
-  stat       = "Average"
-}
-
-module "metric_pending_instances" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupPendingInstances"
-  label      = "Pending instances"
-  color      = local.colors.orange
-  period     = 60
-  stat       = "Average"
-}
-
-module "metric_standby_instances" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupStandbyInstances"
-  label      = "Standby instances"
-  color      = local.colors.light_green
-  period     = 60
-  stat       = "Average"
-}
-
-module "metric_terminating_instances" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/AutoScaling"
-  dimensions = local.group_dimensions
-  name       = "GroupTerminatingInstances"
-  label      = "Terminating instances"
-  color      = local.colors.red
-  period     = 60
-  stat       = "Average"
+locals {
+  metrics_utilization_variants = {
+    min     = { stat = "Minimum", color = local.colors.light_orange }
+    average = { stat = "Average", color = local.colors.orange }
+    max     = { stat = "Maximum", color = local.colors.red }
+  }
 }
 
 module "metric_memory_utilization" {
@@ -181,40 +152,26 @@ module "metric_memory_utilization" {
   period     = 60
 }
 
-module "metric_min_memory_utilization" {
-  source = "./../../cloudwatch/metric"
+module "metrics_memory_utilization" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "System/Linux"
-  dimensions = local.group_dimensions
-  name       = "MemoryUtilization"
-  label      = "Minimum memory utilization"
-  color      = local.colors.light_orange
-  stat       = "Minimum"
-  period     = 60
+  vars_map = { for k, variant in local.metrics_utilization_variants : k => {
+    namespace  = "System/Linux"
+    dimensions = local.group_dimensions
+    name       = "MemoryUtilization"
+    label      = "${variant.stat} memory utilization"
+    color      = variant.color
+    stat       = variant.stat
+    period     = 60
+  } }
 }
 
-module "metric_average_memory_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_dimensions
-  name       = "MemoryUtilization"
-  label      = "Average memory utilization"
-  color      = local.colors.orange
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_max_memory_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_dimensions
-  name       = "MemoryUtilization"
-  label      = "Maximum memory utilization"
-  color      = local.colors.red
-  stat       = "Maximum"
-  period     = 60
+locals {
+  metrics_swap_utilization_variants = {
+    min     = { stat = "Minimum", color = local.colors.light_pink }
+    average = { stat = "Average", color = local.colors.pink }
+    max     = { stat = "Maximum", color = local.colors.purple }
+  }
 }
 
 module "metric_swap_utilization" {
@@ -228,76 +185,32 @@ module "metric_swap_utilization" {
   period     = 60
 }
 
-module "metric_min_swap_utilization" {
-  source = "./../../cloudwatch/metric"
+module "metrics_swap_utilization" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "System/Linux"
-  dimensions = local.group_dimensions
-  name       = "SwapUtilization"
-  label      = "Minimum swap utilization"
-  color      = local.colors.light_pink
-  stat       = "Minimum"
-  period     = 60
+  vars_map = { for k, variant in local.metrics_swap_utilization_variants : k => {
+    namespace  = "System/Linux"
+    dimensions = local.group_dimensions
+    name       = "SwapUtilization"
+    label      = "${variant.stat} swap utilization"
+    color      = variant.color
+    stat       = variant.stat
+    period     = 60
+  } }
 }
 
-module "metric_average_swap_utilization" {
-  source = "./../../cloudwatch/metric"
+module "metrics_cpu_utilization" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "System/Linux"
-  dimensions = local.group_dimensions
-  name       = "SwapUtilization"
-  label      = "Average swap utilization"
-  color      = local.colors.pink
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_max_swap_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_dimensions
-  name       = "SwapUtilization"
-  label      = "Maximum swap utilization"
-  color      = local.colors.purple
-  stat       = "Maximum"
-  period     = 60
-}
-
-module "metric_min_cpu_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "CPUUtilization"
-  label      = "Minimum CPU utilization"
-  color      = local.colors.light_orange
-  stat       = "Minimum"
-  period     = 60
-}
-
-module "metric_average_cpu_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "CPUUtilization"
-  label      = "Average CPU utilization"
-  color      = local.colors.orange
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_max_cpu_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "CPUUtilization"
-  label      = "Maximum CPU utilization"
-  color      = local.colors.red
-  stat       = "Maximum"
-  period     = 60
+  vars_map = { for k, variant in local.metrics_utilization_variants : k => {
+    namespace  = "AWS/EC2"
+    dimensions = local.group_dimensions
+    name       = "CPUUtilization"
+    label      = "${variant.stat} CPU utilization"
+    color      = variant.color
+    stat       = variant.stat
+    period     = 60
+  } }
 }
 
 module "metric_cpu_credit_usage" {
@@ -311,40 +224,38 @@ module "metric_cpu_credit_usage" {
   period     = 300
 }
 
-module "metric_cpu_credit_balance" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "CPUCreditBalance"
-  label      = "CPU credit balance"
-  color      = local.colors.green
-  stat       = "Average"
-  period     = 300
+locals {
+  metrics_cpu_credit_balance = {
+    balance = {
+      name  = "CPUCreditBalance"
+      label = "CPU credit balance"
+      color = local.colors.green
+    }
+    surplus = {
+      name  = "CPUSurplusCreditBalance"
+      label = "CPU surplus credit balance"
+      color = local.colors.orange
+    }
+    surplus_charged = {
+      name  = "CPUSurplusCreditsCharged"
+      label = "CPU surplus credits charged"
+      color = local.colors.red
+    }
+  }
 }
 
-module "metric_cpu_surplus_credit_balance" {
-  source = "./../../cloudwatch/metric"
+module "metrics_cpu_credit_balance" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "CPUSurplusCreditBalance"
-  label      = "CPU surplus credit balance"
-  color      = local.colors.orange
-  stat       = "Average"
-  period     = 300
-}
-
-module "metric_cpu_surplus_credits_charged" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "CPUSurplusCreditsCharged"
-  label      = "CPU surplus credits charged"
-  color      = local.colors.red
-  stat       = "Average"
-  period     = 300
+  vars_map = { for k, variant in local.metrics_cpu_credit_balance : k => {
+    namespace  = "AWS/EC2"
+    dimensions = local.group_dimensions
+    name       = variant.name
+    label      = variant.label
+    color      = variant.color
+    stat       = "Average"
+    period     = 300
+  } }
 }
 
 locals {
@@ -354,273 +265,158 @@ locals {
   })
 }
 
-module "metric_min_root_fs_utilization" {
-  source = "./../../cloudwatch/metric"
+module "metrics_root_fs_utilization" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "System/Linux"
-  dimensions = local.group_root_fs_dimensions
-  name       = "DiskSpaceUtilization"
-  label      = "Minimum root filesystem utilization"
-  color      = local.colors.light_orange
-  stat       = "Minimum"
-  period     = 60
-}
-
-module "metric_average_root_fs_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_root_fs_dimensions
-  name       = "DiskSpaceUtilization"
-  label      = "Average root filesystem utilization"
-  color      = local.colors.orange
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_max_root_fs_utilization" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_root_fs_dimensions
-  name       = "DiskSpaceUtilization"
-  label      = "Maximum root filesystem utilization"
-  color      = local.colors.red
-  stat       = "Maximum"
-  period     = 60
-}
-
-module "metric_min_root_fs_free" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_root_fs_dimensions
-  name       = "DiskSpaceAvailable"
-  label      = "Minimum root filesystem free space"
-  color      = local.colors.red
-  stat       = "Minimum"
-  period     = 60
-}
-
-module "metric_average_root_fs_free" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_root_fs_dimensions
-  name       = "DiskSpaceAvailable"
-  label      = "Average root filesystem free space"
-  color      = local.colors.orange
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_max_root_fs_free" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "System/Linux"
-  dimensions = local.group_root_fs_dimensions
-  name       = "DiskSpaceAvailable"
-  label      = "Maximum root filesystem free space"
-  color      = local.colors.light_orange
-  stat       = "Maximum"
-  period     = 60
+  vars_map = { for k, variant in local.metrics_utilization_variants : k => {
+    namespace  = "System/Linux"
+    dimensions = local.group_root_fs_dimensions
+    name       = "DiskSpaceUtilization"
+    label      = "${variant.stat} root filesystem utilization"
+    color      = variant.color
+    stat       = variant.stat
+    period     = 60
+  } }
 }
 
 locals {
-  fs_colors = {
-    read  = local.colors.green
-    write = local.colors.orange
+  metrics_fs_free_variants = {
+    min     = { stat = "Minimum", color = local.colors.red }
+    average = { stat = "Average", color = local.colors.orange }
+    max     = { stat = "Maximum", color = local.colors.light_orange }
   }
 }
 
-module "metric_fs_bytes_read" {
-  source = "./../../cloudwatch/metric"
+module "metrics_root_fs_free" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSReadBytes"
-  label      = "Bytes read"
-  color      = local.fs_colors.read
-  stat       = "Sum"
-  period     = 60
+  vars_map = { for k, variant in local.metrics_fs_free_variants : k => {
+    namespace  = "System/Linux"
+    dimensions = local.group_root_fs_dimensions
+    name       = "DiskSpaceAvailable"
+    label      = "${variant.stat} root filesystem free space"
+    color      = variant.color
+    stat       = variant.stat
+    period     = 60
+  } }
 }
 
-module "metric_average_fs_bytes_read" {
-  source = "./../../cloudwatch/metric"
+locals {
+  io_colors = {
+    read  = local.colors.green
+    write = local.colors.orange
+  }
 
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSReadBytes"
-  label      = "Average bytes read"
-  color      = local.fs_colors.read
-  stat       = "Average"
-  period     = 60
+  io_metrics = {
+    fs_bytes_read = {
+      name  = "EBSReadBytes"
+      label = "Bytes read"
+      color = local.io_colors.read
+      stat  = "Sum"
+    }
+    average_fs_bytes_read = {
+      name  = "EBSReadBytes"
+      label = "Average bytes read"
+      color = local.io_colors.read
+      stat  = "Average"
+    }
+    fs_reads = {
+      name  = "EBSReadOps"
+      label = "Reads"
+      color = local.io_colors.read
+      stat  = "Sum"
+    }
+    average_fs_reads = {
+      name  = "EBSReadOps"
+      label = "Average reads"
+      color = local.io_colors.read
+      stat  = "Average"
+    }
+    fs_bytes_written = {
+      name  = "EBSWriteBytes"
+      label = "Bytes written"
+      color = local.io_colors.write
+      stat  = "Sum"
+    }
+    average_fs_bytes_written = {
+      name  = "EBSWriteBytes"
+      label = "Average bytes written"
+      color = local.io_colors.write
+      stat  = "Average"
+    }
+    fs_writes = {
+      name  = "EBSWriteOps"
+      label = "Writes"
+      color = local.io_colors.write
+      stat  = "Sum"
+    }
+    average_fs_writes = {
+      name  = "EBSWriteOps"
+      label = "Average writes"
+      color = local.io_colors.write
+      stat  = "Average"
+    }
+    bytes_received = {
+      name  = "NetworkIn"
+      label = "Received bytes"
+      color = local.io_colors.read
+      stat  = "Sum"
+    }
+    average_bytes_received = {
+      name  = "NetworkIn"
+      label = "Average received bytes"
+      color = local.io_colors.read
+      stat  = "Average"
+    }
+    packets_received = {
+      name  = "NetworkPacketsIn"
+      label = "Received packets"
+      color = local.io_colors.read
+      stat  = "Sum"
+    }
+    average_packets_received = {
+      name  = "NetworkPacketsIn"
+      label = "Average received packets"
+      color = local.io_colors.read
+      stat  = "Average"
+    }
+    bytes_sent = {
+      name  = "NetworkOut"
+      label = "Received bytes"
+      color = local.io_colors.write
+      stat  = "Sum"
+    }
+    average_bytes_sent = {
+      name  = "NetworkOut"
+      label = "Average sent bytes"
+      color = local.io_colors.write
+      stat  = "Average"
+    }
+    packets_sent = {
+      name  = "NetworkPacketsOut"
+      label = "Received packets"
+      color = local.io_colors.write
+      stat  = "Sum"
+    }
+    average_packets_sent = {
+      name  = "NetworkPacketsOut"
+      label = "Average sent packets"
+      color = local.io_colors.write
+      stat  = "Average"
+    }
+  }
 }
 
-module "metric_fs_reads" {
-  source = "./../../cloudwatch/metric"
+module "metrics_io" {
+  source = "./../../cloudwatch/metric/many"
 
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSReadOps"
-  label      = "Reads"
-  color      = local.fs_colors.read
-  stat       = "Sum"
-  period     = 60
-}
-
-module "metric_average_fs_reads" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSReadOps"
-  label      = "Average reads"
-  color      = local.fs_colors.read
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_fs_bytes_written" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSWriteBytes"
-  label      = "Bytes written"
-  color      = local.fs_colors.write
-  stat       = "Sum"
-  period     = 60
-}
-
-module "metric_average_fs_bytes_written" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSWriteBytes"
-  label      = "Average bytes written"
-  color      = local.fs_colors.write
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_fs_writes" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSWriteOps"
-  label      = "Writes"
-  color      = local.fs_colors.write
-  stat       = "Sum"
-  period     = 60
-}
-
-module "metric_average_fs_writes" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "EBSWriteOps"
-  label      = "Average writes"
-  color      = local.fs_colors.write
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_bytes_received" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkIn"
-  label      = "Received bytes"
-  color      = local.fs_colors.read
-  stat       = "Sum"
-  period     = 60
-}
-
-module "metric_average_bytes_received" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkIn"
-  label      = "Average received bytes"
-  color      = local.fs_colors.read
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_packets_received" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkPacketsIn"
-  label      = "Received packets"
-  color      = local.fs_colors.read
-  stat       = "Sum"
-  period     = 60
-}
-
-module "metric_average_packets_received" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkPacketsIn"
-  label      = "Average received packets"
-  color      = local.fs_colors.read
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_bytes_sent" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkOut"
-  label      = "Received bytes"
-  color      = local.fs_colors.write
-  stat       = "Sum"
-  period     = 60
-}
-
-module "metric_average_bytes_sent" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkOut"
-  label      = "Average sent bytes"
-  color      = local.fs_colors.write
-  stat       = "Average"
-  period     = 60
-}
-
-module "metric_packets_sent" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkPacketsOut"
-  label      = "Received packets"
-  color      = local.fs_colors.write
-  stat       = "Sum"
-  period     = 60
-}
-
-module "metric_average_packets_sent" {
-  source = "./../../cloudwatch/metric"
-
-  namespace  = "AWS/EC2"
-  dimensions = local.group_dimensions
-  name       = "NetworkPacketsOut"
-  label      = "Average sent packets"
-  color      = local.fs_colors.write
-  stat       = "Average"
-  period     = 60
+  vars_map = { for k, variant in local.io_metrics : k => {
+    namespace  = "AWS/EC2"
+    dimensions = local.group_dimensions
+    name       = variant.name
+    label      = variant.label
+    color      = variant.color
+    stat       = variant.stat
+    period     = 60
+  } }
 }

--- a/ecs/host_group/outputs.tf
+++ b/ecs/host_group/outputs.tf
@@ -7,3 +7,13 @@ output "arn" {
   value       = var.create ? aws_autoscaling_group.hosts[0].arn : null
   description = "Autoscaling group ARN"
 }
+
+output "metrics" {
+  description = "Cloudwatch metrics, see [metrics.tf](./metrics.tf)"
+  value       = local.metrics
+}
+
+output "widgets" {
+  description = "Cloudwatch dashboard widgets, see [widgets.tf](./widgets.tf)"
+  value       = local.widgets
+}

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -1,5 +1,35 @@
 locals {
   widgets = {
-
+    instance_scaling = module.widget_instance_scaling
+    instance_states  = module.widget_instance_states
   }
+}
+
+module "widget_instance_scaling" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title = "${var.name} group scaling"
+  left_metrics = [
+    local.metrics.min_instances,
+    local.metrics.max_instances,
+    local.metrics.desired_instances,
+    local.metrics.pending_instances,
+    local.metrics.terminating_instances,
+    local.metrics.in_service_instances,
+  ]
+  left_range = [0, null]
+}
+
+module "widget_instance_states" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title   = "${var.name} group scaling"
+  stacked = true
+  left_metrics = [
+    local.metrics.pending_instances,
+    local.metrics.terminating_instances,
+    local.metrics.standby_instances,
+    local.metrics.in_service_instances,
+  ]
+  left_range = [0, null]
 }

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -10,6 +10,8 @@ locals {
     root_fs_free        = module.widget_root_fs_free
     fs_io_bytes         = module.widget_fs_io_bytes
     fs_io_ops           = module.widget_fs_io_ops
+    network_bytes       = module.widget_network_bytes
+    network_packets     = module.widget_network_packets
   }
 }
 
@@ -134,6 +136,30 @@ module "widget_fs_io_ops" {
   left_metrics = [
     local.metrics.average_fs_writes,
     local.metrics.average_fs_reads,
+  ]
+  left_range = [0, null]
+}
+
+module "widget_network_bytes" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title   = "${var.name} group network traffic"
+  stacked = true
+  left_metrics = [
+    local.metrics.average_bytes_sent,
+    local.metrics.average_bytes_received,
+  ]
+  left_range = [0, null]
+}
+
+module "widget_network_packets" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title   = "${var.name} group network traffic"
+  stacked = true
+  left_metrics = [
+    local.metrics.average_packets_sent,
+    local.metrics.average_packets_received,
   ]
   left_range = [0, null]
 }

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -13,8 +13,8 @@ module "widget_instance_scaling" {
     local.metrics.min_instances,
     local.metrics.max_instances,
     local.metrics.desired_instances,
-    local.metrics.pending_instances,
     local.metrics.terminating_instances,
+    local.metrics.pending_instances,
     local.metrics.in_service_instances,
   ]
   left_range = [0, null]
@@ -26,8 +26,8 @@ module "widget_instance_states" {
   title   = "${var.name} group scaling"
   stacked = true
   left_metrics = [
-    local.metrics.pending_instances,
     local.metrics.terminating_instances,
+    local.metrics.pending_instances,
     local.metrics.standby_instances,
     local.metrics.in_service_instances,
   ]

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -4,6 +4,8 @@ locals {
     instance_states    = module.widget_instance_states
     memory_utilization = module.widget_memory_utilization
     cpu_utilization    = module.widget_cpu_utilization
+    cpu_credit_balance = module.widget_cpu_credit_balance
+    cpu_credit_usage   = module.widget_cpu_credit_usage
   }
 }
 
@@ -61,4 +63,25 @@ module "widget_cpu_utilization" {
     local.metrics.max_cpu_utilization,
   ]
   left_range = [0, 100]
+}
+
+module "widget_cpu_credit_balance" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title   = "${var.name} group CPU credit balance"
+  stacked = true
+  left_metrics = [
+    local.metrics.cpu_surplus_credits_charged,
+    local.metrics.cpu_surplus_credit_balance,
+    local.metrics.cpu_credit_balance,
+  ]
+  left_range = [0, null]
+}
+
+module "widget_cpu_credit_usage" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title        = "${var.name} group CPU credit usage"
+  left_metrics = [local.metrics.cpu_credit_usage]
+  left_range   = [0, null]
 }

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -1,0 +1,5 @@
+locals {
+  widgets = {
+
+  }
+}

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -8,6 +8,8 @@ locals {
     cpu_credit_usage    = module.widget_cpu_credit_usage
     root_fs_utilization = module.widget_root_fs_utilization
     root_fs_free        = module.widget_root_fs_free
+    fs_io_bytes         = module.widget_fs_io_bytes
+    fs_io_ops           = module.widget_fs_io_ops
   }
 }
 
@@ -108,6 +110,30 @@ module "widget_root_fs_free" {
     local.metrics.min_root_fs_free,
     local.metrics.average_root_fs_free,
     local.metrics.max_root_fs_free,
+  ]
+  left_range = [0, null]
+}
+
+module "widget_fs_io_bytes" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title   = "${var.name} group filesystem IO"
+  stacked = true
+  left_metrics = [
+    local.metrics.average_fs_bytes_written,
+    local.metrics.average_fs_bytes_read,
+  ]
+  left_range = [0, null]
+}
+
+module "widget_fs_io_ops" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title   = "${var.name} group filesystem IO"
+  stacked = true
+  left_metrics = [
+    local.metrics.average_fs_writes,
+    local.metrics.average_fs_reads,
   ]
   left_range = [0, null]
 }

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -1,7 +1,8 @@
 locals {
   widgets = {
-    instance_scaling = module.widget_instance_scaling
-    instance_states  = module.widget_instance_states
+    instance_scaling   = module.widget_instance_scaling
+    instance_states    = module.widget_instance_states
+    memory_utilization = module.widget_memory_utilization
   }
 }
 
@@ -32,4 +33,19 @@ module "widget_instance_states" {
     local.metrics.in_service_instances,
   ]
   left_range = [0, null]
+}
+
+module "widget_memory_utilization" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title = "${var.name} group memory utilization"
+  left_metrics = [
+    local.metrics.min_memory_utilization,
+    local.metrics.average_memory_utilization,
+    local.metrics.max_memory_utilization,
+    local.metrics.min_swap_utilization,
+    local.metrics.average_swap_utilization,
+    local.metrics.max_swap_utilization,
+  ]
+  left_range = [0, 100]
 }

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -1,11 +1,13 @@
 locals {
   widgets = {
-    instance_scaling   = module.widget_instance_scaling
-    instance_states    = module.widget_instance_states
-    memory_utilization = module.widget_memory_utilization
-    cpu_utilization    = module.widget_cpu_utilization
-    cpu_credit_balance = module.widget_cpu_credit_balance
-    cpu_credit_usage   = module.widget_cpu_credit_usage
+    instance_scaling    = module.widget_instance_scaling
+    instance_states     = module.widget_instance_states
+    memory_utilization  = module.widget_memory_utilization
+    cpu_utilization     = module.widget_cpu_utilization
+    cpu_credit_balance  = module.widget_cpu_credit_balance
+    cpu_credit_usage    = module.widget_cpu_credit_usage
+    root_fs_utilization = module.widget_root_fs_utilization
+    root_fs_free        = module.widget_root_fs_free
   }
 }
 
@@ -84,4 +86,28 @@ module "widget_cpu_credit_usage" {
   title        = "${var.name} group CPU credit usage"
   left_metrics = [local.metrics.cpu_credit_usage]
   left_range   = [0, null]
+}
+
+module "widget_root_fs_utilization" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title = "${var.name} group root filesystem utilization"
+  left_metrics = [
+    local.metrics.min_root_fs_utilization,
+    local.metrics.average_root_fs_utilization,
+    local.metrics.max_root_fs_utilization,
+  ]
+  left_range = [0, 100]
+}
+
+module "widget_root_fs_free" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title = "${var.name} group root filesystem free space"
+  left_metrics = [
+    local.metrics.min_root_fs_free,
+    local.metrics.average_root_fs_free,
+    local.metrics.max_root_fs_free,
+  ]
+  left_range = [0, null]
 }

--- a/ecs/host_group/widgets.tf
+++ b/ecs/host_group/widgets.tf
@@ -3,6 +3,7 @@ locals {
     instance_scaling   = module.widget_instance_scaling
     instance_states    = module.widget_instance_states
     memory_utilization = module.widget_memory_utilization
+    cpu_utilization    = module.widget_cpu_utilization
   }
 }
 
@@ -46,6 +47,18 @@ module "widget_memory_utilization" {
     local.metrics.min_swap_utilization,
     local.metrics.average_swap_utilization,
     local.metrics.max_swap_utilization,
+  ]
+  left_range = [0, 100]
+}
+
+module "widget_cpu_utilization" {
+  source = "./../../cloudwatch/metric_widget"
+
+  title = "${var.name} group CPU utilization"
+  left_metrics = [
+    local.metrics.min_cpu_utilization,
+    local.metrics.average_cpu_utilization,
+    local.metrics.max_cpu_utilization,
   ]
   left_range = [0, 100]
 }


### PR DESCRIPTION
- [x] Added `ecs/host_group` cloudwatch metrics:
    - min, max, desired instance count
    - instance count by state
    - memory, swap, cpu, root filesystem utilization (min, average, max)
    - cpu credit balance
    - root filesystem free space (min, max, average)
    - filesystem and network IO
- [x] Added `ecs/host_group` cloudwatch dashboard widgets:
    - scaling
    - breakdown of instance counts by state
    - memory, swap, cpu, root filesystem utilization
    - cpu credit balance
    - root filesystem free space
    - filesystem and network IO

Example dashboard:

![image](https://user-images.githubusercontent.com/803496/80494771-593c9200-8967-11ea-9c74-97083993ea7b.png)

Related to #43 