### PR TITLE
feat(cloudwatch): added modules for creating many metrics at once

### DIFF
--- a/cloudwatch/metric/many/README.md
+++ b/cloudwatch/metric/many/README.md
@@ -12,11 +12,11 @@ Same as [cloudwatch/metric](./..) but allows for creating many metrics using a s
 
 ## Inputs
 
-* `vars` (`any`, required)
+* `vars` (`any`, default: `[]`)
 
     List of [cloudwatch/metric](./..) variables
 
-* `vars_map` (`any`, required)
+* `vars_map` (`any`, default: `{}`)
 
     Map of [cloudwatch/metric](./..) variables
 

--- a/cloudwatch/metric/many/README.md
+++ b/cloudwatch/metric/many/README.md
@@ -1,0 +1,33 @@
+# cloudwatch/metric/many
+
+Same as [cloudwatch/metric](./..) but allows for creating many metrics using a single module
+
+<!-- bin/docs -->
+
+## Versions
+
+| Provider | Requirements |
+|-|-|
+| terraform | `>= 0.12` |
+
+## Inputs
+
+* `vars` (`any`, required)
+
+    List of [cloudwatch/metric](./..) variables
+
+* `vars_map` (`any`, required)
+
+    Map of [cloudwatch/metric](./..) variables
+
+
+
+## Outputs
+
+* `out`
+
+    List of [cloudwatch/metric](./..) outputs
+
+* `out_map`
+
+    Map of [cloudwatch/metric](./..) outputs

--- a/cloudwatch/metric/many/main.tf
+++ b/cloudwatch/metric/many/main.tf
@@ -1,0 +1,48 @@
+module "default" {
+  source = "./.."
+
+  namespace = ""
+  name      = ""
+}
+
+locals {
+  out = [for v in var.vars : {
+    id = "m_${v.name}_${md5(jsonencode([
+      v.namespace,
+      v.name,
+      try(v.dimensions, module.default.dimensions),
+      try(v.period, module.default.period),
+      try(v.stat, module.default.stat),
+      try(v.label, module.default.label),
+      try(v.color, module.default.color),
+    ]))}"
+
+    namespace  = v.namespace
+    name       = v.name
+    dimensions = try(v.dimensions, module.default.dimensions)
+    period     = try(v.period, module.default.period)
+    stat       = try(v.stat, module.default.stat)
+    label      = try(v.label, module.default.label)
+    color      = try(v.color, module.default.color)
+  }]
+
+  out_map = { for k, v in var.vars_map : k => {
+    id = "m_${v.name}_${md5(jsonencode([
+      v.namespace,
+      v.name,
+      try(v.dimensions, module.default.dimensions),
+      try(v.period, module.default.period),
+      try(v.stat, module.default.stat),
+      try(v.label, module.default.label),
+      try(v.color, module.default.color),
+    ]))}"
+
+    namespace  = v.namespace
+    name       = v.name
+    dimensions = try(v.dimensions, module.default.dimensions)
+    period     = try(v.period, module.default.period)
+    stat       = try(v.stat, module.default.stat)
+    label      = try(v.label, module.default.label)
+    color      = try(v.color, module.default.color)
+  } }
+}

--- a/cloudwatch/metric/many/outputs.tf
+++ b/cloudwatch/metric/many/outputs.tf
@@ -1,0 +1,9 @@
+output "out" {
+  description = "List of [cloudwatch/metric](./..) outputs"
+  value       = local.out
+}
+
+output "out_map" {
+  description = "Map of [cloudwatch/metric](./..) outputs"
+  value       = local.out_map
+}

--- a/cloudwatch/metric/many/variables.tf
+++ b/cloudwatch/metric/many/variables.tf
@@ -1,9 +1,11 @@
 variable "vars" {
   description = "List of [cloudwatch/metric](./..) variables"
   type        = any
+  default     = []
 }
 
 variable "vars_map" {
   description = "Map of [cloudwatch/metric](./..) variables"
   type        = any
+  default     = {}
 }

--- a/cloudwatch/metric/many/variables.tf
+++ b/cloudwatch/metric/many/variables.tf
@@ -1,0 +1,9 @@
+variable "vars" {
+  description = "List of [cloudwatch/metric](./..) variables"
+  type        = any
+}
+
+variable "vars_map" {
+  description = "Map of [cloudwatch/metric](./..) variables"
+  type        = any
+}

--- a/cloudwatch/metric/many/versions.tf
+++ b/cloudwatch/metric/many/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/cloudwatch/metric_expression/many/README.md
+++ b/cloudwatch/metric_expression/many/README.md
@@ -12,11 +12,11 @@ Same as [cloudwatch/metric_expression](./..) but allows for creating many metric
 
 ## Inputs
 
-* `vars` (`any`, required)
+* `vars` (`any`, default: `[]`)
 
     List of [cloudwatch/metric_expression](./..) variables
 
-* `vars_map` (`any`, required)
+* `vars_map` (`any`, default: `{}`)
 
     Map of [cloudwatch/metric_expression](./..) variables
 

--- a/cloudwatch/metric_expression/many/README.md
+++ b/cloudwatch/metric_expression/many/README.md
@@ -1,0 +1,33 @@
+# cloudwatch/metric_expression/many
+
+Same as [cloudwatch/metric_expression](./..) but allows for creating many metrics using a single module
+
+<!-- bin/docs -->
+
+## Versions
+
+| Provider | Requirements |
+|-|-|
+| terraform | `>= 0.12` |
+
+## Inputs
+
+* `vars` (`any`, required)
+
+    List of [cloudwatch/metric_expression](./..) variables
+
+* `vars_map` (`any`, required)
+
+    Map of [cloudwatch/metric_expression](./..) variables
+
+
+
+## Outputs
+
+* `out`
+
+    List of [cloudwatch/metric_expression](./..) outputs
+
+* `out_map`
+
+    Map of [cloudwatch/metric_expression](./..) outputs

--- a/cloudwatch/metric_expression/many/main.tf
+++ b/cloudwatch/metric_expression/many/main.tf
@@ -1,0 +1,31 @@
+module "default" {
+  source = "./.."
+
+  expression = ""
+}
+
+locals {
+  out = [for v in var.vars : {
+    id = "e_${md5(jsonencode([
+      v.expression,
+      try(v.label, module.default.label),
+      try(v.color, module.default.color),
+    ]))}"
+
+    expression = v.expression
+    label      = try(v.label, module.default.label)
+    color      = try(v.color, module.default.color)
+  }]
+
+  out_map = { for k, v in var.vars_map : k => {
+    id = "e_${md5(jsonencode([
+      v.expression,
+      try(v.label, module.default.label),
+      try(v.color, module.default.color),
+    ]))}"
+
+    expression = v.expression
+    label      = try(v.label, module.default.label)
+    color      = try(v.color, module.default.color)
+  } }
+}

--- a/cloudwatch/metric_expression/many/outputs.tf
+++ b/cloudwatch/metric_expression/many/outputs.tf
@@ -1,0 +1,9 @@
+output "out" {
+  description = "List of [cloudwatch/metric_expression](./..) outputs"
+  value       = local.out
+}
+
+output "out_map" {
+  description = "Map of [cloudwatch/metric_expression](./..) outputs"
+  value       = local.out_map
+}

--- a/cloudwatch/metric_expression/many/variables.tf
+++ b/cloudwatch/metric_expression/many/variables.tf
@@ -1,0 +1,9 @@
+variable "vars" {
+  description = "List of [cloudwatch/metric_expression](./..) variables"
+  type        = any
+}
+
+variable "vars_map" {
+  description = "Map of [cloudwatch/metric_expression](./..) variables"
+  type        = any
+}

--- a/cloudwatch/metric_expression/many/variables.tf
+++ b/cloudwatch/metric_expression/many/variables.tf
@@ -1,9 +1,11 @@
 variable "vars" {
   description = "List of [cloudwatch/metric_expression](./..) variables"
   type        = any
+  default     = []
 }
 
 variable "vars_map" {
   description = "Map of [cloudwatch/metric_expression](./..) variables"
   type        = any
+  default     = {}
 }

--- a/cloudwatch/metric_expression/many/versions.tf
+++ b/cloudwatch/metric_expression/many/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
- [x] added `cloudwatch/metric/many` for creating multiple metrics in one module
- [x] added `cloudwatch/metric_expression/many` for creating multiple expressions in one module

Needed for #71 to create metrics for a variable number of NAT instances