### PR TITLE
docs: removed codequest.com from examples

### DIFF
--- a/ses/domain/example/main.tf
+++ b/ses/domain/example/main.tf
@@ -2,17 +2,21 @@ provider "aws" {
   region = "eu-west-1" # Ireland
 }
 
-data "aws_route53_zone" "cq" {
-  name         = "codequest.com."
+variable "zone_domain" {
+  type        = string
+  description = "Domain of the Route53 hosted zone to add example records to"
+}
+
+data "aws_route53_zone" "zone" {
+  name         = var.zone_domain
   private_zone = false
 }
 
 module "domain" {
   source = "./.."
 
-  name                = "ses-domain.terraform-modules-example.codequest.com"
-  hosted_zone_id      = data.aws_route53_zone.cq.id
-  dmarc_report_emails = ["marek@codequest.com"]
+  name           = "ses-domain.terraform-modules-examples.${var.zone_domain}"
+  hosted_zone_id = data.aws_route53_zone.zone.id
 }
 
 output "sender_policy_arn" {

--- a/ssl/acm/example/main.tf
+++ b/ssl/acm/example/main.tf
@@ -2,24 +2,29 @@ provider "aws" {
   region = "eu-west-1" # Ireland
 }
 
-data "aws_route53_zone" "cq" {
-  name         = "codequest.com."
+variable "zone_domain" {
+  type        = string
+  description = "Domain of the Route53 hosted zone to add example records to"
+}
+
+data "aws_route53_zone" "zone" {
+  name         = var.zone_domain
   private_zone = false
 }
 
 module "certificate" {
   source = "./.."
 
+  hosted_zone_id = data.aws_route53_zone.zone.zone_id
   domains = [
-    "terraform-modules-ssl-demo.codequest.com",
-    "www.terraform-modules-ssl-demo.codequest.com",
+    "ssl.terraform-modules-example.${var.zone_domain}",
+    "www.ssl.terraform-modules-example.${var.zone_domain}",
   ]
 
-  hosted_zone_id = data.aws_route53_zone.cq.zone_id
-
   tags = {
-    Project = "terraform-modules"
-    Module  = "ssl"
+    Project     = "terraform-modules"
+    Environment = "example"
+    Module      = "ssl"
   }
 }
 


### PR DESCRIPTION
- [x] replaced `codequest.com` with `zone_domain` variable in examples which need a hosted zone