### PR TITLE
fix(build): random CI out of memory errors due to over-parallelization

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,10 +43,6 @@ node {
       }
     }
 
-    def shEachDir = { dirs, errorMessage, scriptFactory ->
-      runEachDir dirs, errorMessage, { dir -> sh(scriptFactory(dir)) }
-    }
-
     try {
       stage("download providers") {
         sh 'terraform init -backend=false -upgrade=true'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node {
         })
       }
 
-      stage("terraform fmt") {
+      stage("terraform fmt modules") {
         runEachDir(moduleDirs, "Formatting error", { moduleDir ->
           sh "cd ${moduleDir} && terraform fmt -check -diff"
         })
@@ -105,6 +105,12 @@ node {
         runEachDir exampleDirs, "Failed to init", { exampleDir ->
           sh "cd ${exampleDir} && terraform init -backend=false -plugin-dir='${pluginsDir}'"
         }
+      }
+
+      stage("terraform fmt examples") {
+        runEachDir(exampleDirs, "Formatting error", { exampleDir ->
+          sh "cd ${exampleDir} && terraform fmt -check -diff"
+        })
       }
 
       stage("terraform validate examples") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,9 +37,8 @@ node {
         }
       }
 
-      def failedDirs = dirStatuses.findAll({ !it.value }).collect({ it.key })
-      if (failedDirs.size() > 0) {
-        error("${errorMessage}:\n${failedModules.join('\n')}")
+      if (dirStatuses.any({ !it.value })) {
+        error(errorMessage)
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,25 +99,7 @@ node {
           },
           "modules: docs updated": {
             moduleStage("docs updated") { dir ->
-              def moduleReadme = "${dir}/README.md"
-
-              if (!fileExists(moduleReadme)) {
-                error("Missing ${moduleReadme}")
-              }
-
-              try {
-                sh "cat '${moduleReadme}' | grep -qF '<!-- bin/docs -->'"
-              } catch (err) {
-                error("Missing bin/docs marker in ${moduleReadme}")
-              }
-
-              try {
-                sh "\$TOOLS_BIN/update-docs '${moduleReadme}' && git diff --quiet '${moduleReadme}'"
-              } catch (err) {
-                error("${moduleReadme} is out of date")
-              } finally {
-                sh "git checkout '${moduleReadme}'"
-              }
+              sh "\$TOOLS_BIN/check-docs '${dir}/README.md'"
             }
           },
           "examples: terraform fmt": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,8 +97,8 @@ node {
               sh "cd ${dir} && tflint --config \$TFLINT_CONFIG"
             }
           },
-          "modules: docs updated": {
-            moduleStage("docs updated") { dir ->
+          "modules: check-docs": {
+            moduleStage("check-docs") { dir ->
               sh "\$TOOLS_BIN/check-docs '${dir}/README.md'"
             }
           },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ node {
       }
 
       stage("tflint modules") {
-        runEachDir(moduleDir, "Failed to tflint", { moduleDir ->
+        runEachDir(moduleDirs, "Failed to tflint", { moduleDir ->
           sh "cd ${moduleDir} && tflint --config \$TFLINT_CONFIG"
         })
       }

--- a/ssl/acm/variables.tf
+++ b/ssl/acm/variables.tf
@@ -4,6 +4,11 @@ variable "create" {
   type        = bool
 }
 
+variable "domains" {
+  description = "Certificate domains, have to be in one Route53 hosted zone."
+  type        = list(string)
+}
+
 variable "hosted_zone_id" {
   description = "Route53 hosted zone id for ACM domain ownership validation"
   type        = string

--- a/ssl/acm/variables.tf
+++ b/ssl/acm/variables.tf
@@ -4,11 +4,6 @@ variable "create" {
   type        = bool
 }
 
-variable "domains" {
-  description = "Certificate domains, have to be in one Route53 hosted zone."
-  type        = list(string)
-}
-
 variable "hosted_zone_id" {
   description = "Route53 hosted zone id for ACM domain ownership validation"
   type        = string

--- a/tools/bin/check-docs
+++ b/tools/bin/check-docs
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Check if module documentation is up to date
+#
+# Usage:
+# tools/bin/check-docs module/README.md
+
+set -e
+
+tools=$(dirname $0)
+actual="$1"
+expected="$1.expected"
+
+rm_expected() {
+  rm -f "$expected"
+}
+trap rm_expected EXIT
+
+if [ ! -f "$1" ]; then
+  echo "Missing docs for $(dirname $actual)"
+  exit 1
+fi
+
+if ! grep -qF '<!-- bin/docs -->' <"$actual"; then
+  echo "Missing bin/docs marker in $actual"
+  exit 1
+fi
+
+# generate the expected docs
+manual_docs=$(sed '/<!-- bin\/docs -->/q' "$1")
+generated_docs=$("$tools/docs" "$(dirname $1)")
+printf "%s\n%s\n" "$manual_docs" "$generated_docs" >"$expected"
+
+if diff -q "$actual" "$expected" >/dev/null; then
+  echo "$actual docs are up to date"
+  exit 0
+else
+  echo "$actual docs are outdated, diff:"
+  echo
+  diff -u "$expected" "$actual"
+  exit 1
+fi


### PR DESCRIPTION
Refactored the CI pipeline so it doesn't try to do as many parallel tasks. Previously we would run, eg. `terraform validate` for each module in parallel, which caused some random memory usage problems. 

Now the pipeline looks like this:

![image](https://user-images.githubusercontent.com/803496/81570430-dd980780-93a0-11ea-9436-76466738b40e.png)

and you can drill down to individual modules/examples by just clicking on one of the stages:

![image](https://user-images.githubusercontent.com/803496/81570486-f1dc0480-93a0-11ea-8f58-6d440d6c587b.png)
