### PR TITLE
feat: added terraform/backend/s3 module

### DIFF
--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -13,6 +13,10 @@ Creates resources needed to use a terraform S3 backend with locking
 
 ## Inputs
 
+* `bucket_force_destroy` (`bool`, default: `false`)
+
+    Allow destroying the state bucket even if it's not empty
+
 * `bucket_name` (`string`, required)
 
     State bucket name

--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -1,0 +1,66 @@
+# terraform/backend/s3
+
+Creates resources needed to use a terraform S3 backend with locking
+
+<!-- bin/docs -->
+
+## Versions
+
+| Provider | Requirements |
+|-|-|
+| terraform | `>= 0.12` |
+| `aws` | `>= 2.40.0` |
+
+## Inputs
+
+* `bucket_name` (`string`, required)
+
+    State bucket name
+
+* `create` (`bool`, default: `true`)
+
+    Whether any resources should be created
+
+* `lock_table_name` (`string`, default: `null`)
+
+    DynamoDB lock table name, defaults to `{bucket}-lock`
+
+* `tags` (`map(string)`, default: `{}`)
+
+    Tags to add to resources
+
+
+
+## Outputs
+
+* `backend_config`
+
+    Terraform backend config map
+
+* `backend_config_template`
+
+    Terraform backend block template
+
+* `backend_type`
+
+    Terraform backend type
+
+* `bucket_arn`
+
+    State bucket ARN
+
+* `bucket_name`
+
+    State bucket name
+
+* `lock_table_arn`
+
+    State lock table ARN
+
+* `lock_table_name`
+
+    State lock table name
+
+* `remote_state_template`
+
+    terraform_remote_state block template

--- a/terraform/backend/s3/example/main.tf
+++ b/terraform/backend/s3/example/main.tf
@@ -12,6 +12,11 @@ module "example" {
     Environment = "example"
     Module      = "terraform/backend/s3"
   }
+
+  # Allow destroying the state bucket even if it's not empty,
+  # so we can easily create and destroy the example.
+  # Should not be used in actual deployments.
+  bucket_force_destroy = true
 }
 
 output "backend_config_template" {

--- a/terraform/backend/s3/example/main.tf
+++ b/terraform/backend/s3/example/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = "eu-west-1" # Ireland
+}
+
+module "example" {
+  source = "./.."
+
+  bucket_name = "terraform-modules-s3-backend-example"
+
+  tags = {
+    Project     = "terraform-modules"
+    Environment = "example"
+    Module      = "terraform/backend/s3"
+  }
+}
+
+output "backend_config_template" {
+  value = module.example.backend_config_template
+}
+
+output "remote_state_template" {
+  value = module.example.remote_state_template
+}

--- a/terraform/backend/s3/main.tf
+++ b/terraform/backend/s3/main.tf
@@ -1,9 +1,10 @@
 resource "aws_s3_bucket" "state" {
   count = var.create ? 1 : 0
 
-  bucket = var.bucket_name
-  tags   = var.tags
-  acl    = "private"
+  bucket        = var.bucket_name
+  tags          = var.tags
+  acl           = "private"
+  force_destroy = var.bucket_force_destroy
 
   versioning {
     enabled = true

--- a/terraform/backend/s3/main.tf
+++ b/terraform/backend/s3/main.tf
@@ -1,0 +1,69 @@
+resource "aws_s3_bucket" "state" {
+  count = var.create ? 1 : 0
+
+  bucket = var.bucket_name
+  tags   = var.tags
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_dynamodb_table" "state_lock" {
+  count = var.create ? 1 : 0
+
+  name           = coalesce(var.lock_table_name, "${var.bucket_name}-lock")
+  tags           = var.tags
+  hash_key       = "LockID"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+data "aws_region" "current" {}
+
+locals {
+  region          = data.aws_region.current.name
+  bucket_name     = var.create ? aws_s3_bucket.state[0].bucket : ""
+  bucket_arn      = var.create ? aws_s3_bucket.state[0].arn : ""
+  lock_table_name = var.create ? aws_dynamodb_table.state_lock[0].name : ""
+  lock_table_arn  = var.create ? aws_dynamodb_table.state_lock[0].arn : ""
+
+  backend_type = "s3"
+  backend_config = {
+    region         = local.region
+    bucket         = local.bucket_name
+    dynamodb_table = local.lock_table_name
+    key            = "terraform.tfstate"
+    encrypt        = true
+  }
+
+  # <<-EOF and directives don't seem to work well together,
+  # so using good-old <<EOF
+  backend_config_template = <<EOF
+terraform {
+  backend ${jsonencode(local.backend_type)} {
+    %{~for k, v in local.backend_config~}
+    ${k} = ${jsonencode(v)}
+    %{~endfor~}
+  }
+}
+EOF
+
+  remote_state_template = <<EOF
+data "terraform_remote_state" "remote" {
+  backend = ${jsonencode(local.backend_type)}
+  workspace = "default"
+  config = {
+    %{~for k, v in local.backend_config~}
+    ${k} = ${jsonencode(v)}
+    %{~endfor~}
+  }
+}
+EOF
+}

--- a/terraform/backend/s3/outputs.tf
+++ b/terraform/backend/s3/outputs.tf
@@ -1,0 +1,39 @@
+output "bucket_name" {
+  description = "State bucket name"
+  value       = local.bucket_name
+}
+
+output "bucket_arn" {
+  description = "State bucket ARN"
+  value       = local.bucket_arn
+}
+
+output "lock_table_name" {
+  description = "State lock table name"
+  value       = local.lock_table_name
+}
+
+output "lock_table_arn" {
+  description = "State lock table ARN"
+  value       = local.lock_table_arn
+}
+
+output "backend_type" {
+  description = "Terraform backend type"
+  value       = local.backend_type
+}
+
+output "backend_config" {
+  description = "Terraform backend config map"
+  value       = local.backend_config
+}
+
+output "backend_config_template" {
+  description = "Terraform backend block template"
+  value       = local.backend_config_template
+}
+
+output "remote_state_template" {
+  description = "terraform_remote_state block template"
+  value       = local.remote_state_template
+}

--- a/terraform/backend/s3/variables.tf
+++ b/terraform/backend/s3/variables.tf
@@ -15,6 +15,12 @@ variable "bucket_name" {
   type        = string
 }
 
+variable "bucket_force_destroy" {
+  description = "Allow destroying the state bucket even if it's not empty"
+  type        = bool
+  default     = false
+}
+
 variable "lock_table_name" {
   description = "DynamoDB lock table name, defaults to `{bucket}-lock`"
   type        = string

--- a/terraform/backend/s3/variables.tf
+++ b/terraform/backend/s3/variables.tf
@@ -1,0 +1,22 @@
+variable "create" {
+  description = "Whether any resources should be created"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to add to resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "bucket_name" {
+  description = "State bucket name"
+  type        = string
+}
+
+variable "lock_table_name" {
+  description = "DynamoDB lock table name, defaults to `{bucket}-lock`"
+  type        = string
+  default     = null
+}

--- a/terraform/backend/s3/versions.tf
+++ b/terraform/backend/s3/versions.tf
@@ -3,7 +3,5 @@ terraform {
 
   required_providers {
     aws = ">= 2.40.0"
-
-    # TODO: terraform/backend/s3 specific provider requirements
   }
 }

--- a/terraform/backend/s3/versions.tf
+++ b/terraform/backend/s3/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    aws = ">= 2.40.0"
+
+    # TODO: terraform/backend/s3 specific provider requirements
+  }
+}


### PR DESCRIPTION
- [x] Added `terraform/backend/s3` module which creates necessary resources to setup an S3 backend

Overlaps in functionality with the `meta` module, which we could, and probably should, deprecate going forward, since it assumes a bit too many things.