### PR TITLE
feat(spa): added .well-known/* behavior that doesn't require basic auth

### DIFF
--- a/spa/examples/development/main.tf
+++ b/spa/examples/development/main.tf
@@ -29,6 +29,14 @@ resource "aws_s3_bucket_object" "index" {
   cache_control = "no-cache no-store"
 }
 
+resource "aws_s3_bucket_object" "well_known" {
+  bucket        = module.app.bucket_name
+  key           = ".well-known/meta.txt"
+  content       = "Some .well-known metadata"
+  content_type  = "text/plain"
+  cache_control = "no-cache no-store"
+}
+
 output "app" {
   value = module.app
 }

--- a/spa/main.tf
+++ b/spa/main.tf
@@ -159,6 +159,23 @@ resource "aws_cloudfront_distribution" "assets" {
   price_class         = var.cloudfront_price_class
 
   ordered_cache_behavior {
+    path_pattern           = ".well-known/*"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = aws_s3_bucket.assets[0].id
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  ordered_cache_behavior {
     path_pattern           = "${var.static_path}/*"
     allowed_methods        = ["GET", "HEAD", "OPTIONS"]
     cached_methods         = ["GET", "HEAD", "OPTIONS"]

--- a/spa/main.tf
+++ b/spa/main.tf
@@ -159,7 +159,7 @@ resource "aws_cloudfront_distribution" "assets" {
   price_class         = var.cloudfront_price_class
 
   ordered_cache_behavior {
-    path_pattern           = ".well-known/*"
+    path_pattern           = "/.well-known/*"
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
     target_origin_id       = aws_s3_bucket.assets[0].id


### PR DESCRIPTION
Added a cloudfront behavior for `.well-known/*` which serves assets from `.well-known` without requiring basic authentication. `.well-known` is used by third party services to fetch information about the domain and as such has to be accessible without authentication.