### PR TITLE
 fix(rds/postgres): disable auto_minor_version_upgrade

### DIFF
--- a/rds/postgres/README.md
+++ b/rds/postgres/README.md
@@ -50,7 +50,7 @@ Creates an RDS PostgreSQL database instance
 
     The port on which the DB accepts connections
 
-* `postgres_version` (`string`, default: `"10.6"`)
+* `postgres_version` (`string`, default: `"10.13"`)
 
     RDS Postgres engine version
 

--- a/rds/postgres/example/bin/psql
+++ b/rds/postgres/example/bin/psql
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 environment=${1:-master}
-docker run -it postgres:10.6-alpine psql "$(terraform output ${environment}_db_url)" "$@"
+docker run -it postgres:10.13-alpine psql "$(terraform output ${environment}_db_url)" "$@"

--- a/rds/postgres/main.tf
+++ b/rds/postgres/main.tf
@@ -59,19 +59,20 @@ resource "aws_db_instance" "db" {
 
   identifier = local.name
 
-  engine                    = "postgres"
-  engine_version            = var.postgres_version
-  storage_type              = "gp2"
-  allocated_storage         = var.storage
-  instance_class            = var.instance_type
-  db_subnet_group_name      = aws_db_subnet_group.db[0].name
-  multi_az                  = var.multi_az
-  deletion_protection       = var.prevent_destroy
-  final_snapshot_identifier = "${local.name}-final"
-  vpc_security_group_ids    = [aws_security_group.db[0].id]
-  publicly_accessible       = var.public
-  backup_retention_period   = var.backup_retention_period
-  copy_tags_to_snapshot     = true
+  engine                     = "postgres"
+  engine_version             = var.postgres_version
+  storage_type               = "gp2"
+  allocated_storage          = var.storage
+  instance_class             = var.instance_type
+  db_subnet_group_name       = aws_db_subnet_group.db[0].name
+  multi_az                   = var.multi_az
+  deletion_protection        = var.prevent_destroy
+  final_snapshot_identifier  = "${local.name}-final"
+  vpc_security_group_ids     = [aws_security_group.db[0].id]
+  publicly_accessible        = var.public
+  backup_retention_period    = var.backup_retention_period
+  copy_tags_to_snapshot      = true
+  auto_minor_version_upgrade = false
 
   port     = var.port
   name     = local.db

--- a/rds/postgres/variables.tf
+++ b/rds/postgres/variables.tf
@@ -67,7 +67,7 @@ variable "security_group_ids" {
 variable "postgres_version" {
   description = "RDS Postgres engine version"
   type        = string
-  default     = "10.6"
+  default     = "10.13"
 }
 
 variable "storage" {


### PR DESCRIPTION
When `auto_minor_version_upgrade` is set to `true` (which is the default) the database is automatically upgraded from time to time. This changes are not reflected in Terraform state though, which can lead to unexpected bugs on `terraform apply`, e.g.
`Cannot upgrade postgres from 10.13 to 10.6`

This PR sets explicit `false` to `auto_minor_version_upgrade` and updates default `postgres_version`.