### PR TITLE
feat(ecs/task)!: Added log_retention variable

### DIFF
--- a/ecs/task/README.md
+++ b/ecs/task/README.md
@@ -85,7 +85,11 @@ We recommend creating the task definition using `image` or `image_name` + `image
 
 * `log_retention` (`number`, default: `7`)
 
-    Log retention in days
+        Log retention in days.
+
+    Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+    If you select 0, the events in the log group are always retained and never expire."
+
 
 * `memory_hard_limit` (`number`, default: `1024`)
 

--- a/ecs/task/README.md
+++ b/ecs/task/README.md
@@ -85,10 +85,10 @@ We recommend creating the task definition using `image` or `image_name` + `image
 
 * `log_retention` (`number`, default: `7`)
 
-        Log retention in days.
+    Log retention in days.
 
     Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
-    If you select 0, the events in the log group are always retained and never expire."
+    If you select 0, the events in the log group are always retained and never expire.
 
 
 * `memory_hard_limit` (`number`, default: `1024`)

--- a/ecs/task/README.md
+++ b/ecs/task/README.md
@@ -83,6 +83,10 @@ We recommend creating the task definition using `image` or `image_name` + `image
 
     Container image version tag, if omitted will use one from the latest revision. Used only when image_name is provided.
 
+* `log_retention` (`number`, default: `7`)
+
+    Log retention in days
+
 * `memory_hard_limit` (`number`, default: `1024`)
 
     The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.

--- a/ecs/task/log_group/README.md
+++ b/ecs/task/log_group/README.md
@@ -29,6 +29,10 @@ Creates a CloudWatch log group for a container and outputs container logging con
 
     Kebab-cased project name
 
+* `retention` (`number`, default: `7`)
+
+    Log retention in days
+
 * `tags` (`map(string)`, default: `{}`)
 
     Tags to add to resources that support them

--- a/ecs/task/log_group/README.md
+++ b/ecs/task/log_group/README.md
@@ -31,7 +31,11 @@ Creates a CloudWatch log group for a container and outputs container logging con
 
 * `retention` (`number`, default: `7`)
 
-    Log retention in days
+        Log retention in days.
+
+    Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+    If you select 0, the events in the log group are always retained and never expire."
+
 
 * `tags` (`map(string)`, default: `{}`)
 

--- a/ecs/task/log_group/README.md
+++ b/ecs/task/log_group/README.md
@@ -31,10 +31,10 @@ Creates a CloudWatch log group for a container and outputs container logging con
 
 * `retention` (`number`, default: `7`)
 
-        Log retention in days.
+    Log retention in days.
 
     Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
-    If you select 0, the events in the log group are always retained and never expire."
+    If you select 0, the events in the log group are always retained and never expire.
 
 
 * `tags` (`map(string)`, default: `{}`)

--- a/ecs/task/log_group/main.tf
+++ b/ecs/task/log_group/main.tf
@@ -20,6 +20,8 @@ resource "aws_cloudwatch_log_group" "log" {
 
   name = local.path
   tags = local.tags
+
+  retention_in_days = var.retention
 }
 
 data "aws_region" "current" {

--- a/ecs/task/log_group/variables.tf
+++ b/ecs/task/log_group/variables.tf
@@ -31,3 +31,8 @@ variable "container" {
   default     = ""
 }
 
+variable "retention" {
+  description = "Log retention in days"
+  type        = number
+  default     = 7
+}

--- a/ecs/task/log_group/variables.tf
+++ b/ecs/task/log_group/variables.tf
@@ -32,7 +32,13 @@ variable "container" {
 }
 
 variable "retention" {
-  description = "Log retention in days"
-  type        = number
-  default     = 7
+  description = <<EOF
+    Log retention in days.
+
+    Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+    If you select 0, the events in the log group are always retained and never expire."
+  EOF
+
+  type    = number
+  default = 7
 }

--- a/ecs/task/log_group/variables.tf
+++ b/ecs/task/log_group/variables.tf
@@ -33,10 +33,10 @@ variable "container" {
 
 variable "retention" {
   description = <<EOF
-    Log retention in days.
+Log retention in days.
 
     Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
-    If you select 0, the events in the log group are always retained and never expire."
+    If you select 0, the events in the log group are always retained and never expire.
   EOF
 
   type    = number

--- a/ecs/task/main.tf
+++ b/ecs/task/main.tf
@@ -15,6 +15,8 @@ module "container_log" {
   task        = var.task
   container   = var.container
   tags        = var.tags
+
+  retention = var.log_retention
 }
 
 data "aws_ecs_container_definition" "current" {

--- a/ecs/task/variables.tf
+++ b/ecs/task/variables.tf
@@ -40,9 +40,15 @@ variable "container" {
 }
 
 variable "log_retention" {
-  description = "Log retention in days"
-  type        = number
-  default     = 7
+  description = <<EOF
+    Log retention in days.
+
+    Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+    If you select 0, the events in the log group are always retained and never expire."
+  EOF
+
+  type    = number
+  default = 7
 }
 
 # container_definition

--- a/ecs/task/variables.tf
+++ b/ecs/task/variables.tf
@@ -39,6 +39,12 @@ variable "container" {
   default     = null
 }
 
+variable "log_retention" {
+  description = "Log retention in days"
+  type        = number
+  default     = 7
+}
+
 # container_definition
 
 variable "image" {
@@ -112,4 +118,3 @@ variable "environment_variables" {
   type        = map(string)
   default     = {}
 }
-

--- a/ecs/task/variables.tf
+++ b/ecs/task/variables.tf
@@ -41,10 +41,10 @@ variable "container" {
 
 variable "log_retention" {
   description = <<EOF
-    Log retention in days.
+Log retention in days.
 
     Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
-    If you select 0, the events in the log group are always retained and never expire."
+    If you select 0, the events in the log group are always retained and never expire.
   EOF
 
   type    = number


### PR DESCRIPTION
- [x] Added `log_retention` variable to `ecs/task` module, defaults to 7 days

**BREAKING CHANGES**: 
- [x] previously logs would be kept indefinitely, now we default to 7 days