### PR TITLE
feat(ssl/acm)!: support for aws provider 3.0 and manual validation

### DIFF
--- a/ssl/acm/README.md
+++ b/ssl/acm/README.md
@@ -44,6 +44,10 @@ Creates an SSL certificate using AWS ACM, verifies domain ownership using Route5
 
     Whether to wait for certificate validation
 
+* `validation_record_fqdns` (`list(string)`, default: `null`)
+
+    When `create_validation_records` is `false` you can pass a list of `aws_route53_record.*.fqdn` to make sure validation checks don't start before the records are created.
+
 
 
 ## Outputs
@@ -59,3 +63,7 @@ Creates an SSL certificate using AWS ACM, verifies domain ownership using Route5
 * `validated_arn`
 
     ACM certificate ARN, once it's validated
+
+* `validation_records`
+
+    DNS validation records, in cases where you want to manually create them

--- a/ssl/acm/README.md
+++ b/ssl/acm/README.md
@@ -9,7 +9,7 @@ Creates an SSL certificate using AWS ACM, verifies domain ownership using Route5
 | Provider | Requirements |
 |-|-|
 | terraform | `>= 0.12` |
-| `aws` | `>= 2.40.0` |
+| `aws` | `>= 3.0.0` |
 
 ## Inputs
 

--- a/ssl/acm/README.md
+++ b/ssl/acm/README.md
@@ -32,7 +32,7 @@ Creates an SSL certificate using AWS ACM, verifies domain ownership using Route5
 
     Certificate domains, have to be in one Route53 hosted zone.
 
-* `hosted_zone_id` (`string`, required)
+* `hosted_zone_id` (`string`, default: `null`)
 
     Route53 hosted zone id for ACM domain ownership validation
 

--- a/ssl/acm/example/main.tf
+++ b/ssl/acm/example/main.tf
@@ -49,5 +49,5 @@ module "wildcard_certificate" {
 }
 
 output "wildcard_certificate_arn" {
-  value = module.certificate.validated_arn
+  value = module.wildcard_certificate.validated_arn
 }

--- a/ssl/acm/main.tf
+++ b/ssl/acm/main.tf
@@ -41,7 +41,7 @@ locals {
 
   validation_fqdns = local.create_validation_records ? [
     for key, record in aws_route53_record.validation : record.fqdn
-  ] : []
+  ] : var.validation_record_fqdns
 }
 
 resource "aws_route53_record" "validation" {

--- a/ssl/acm/main.tf
+++ b/ssl/acm/main.tf
@@ -20,29 +20,36 @@ resource "aws_acm_certificate_validation" "cert" {
 }
 
 locals {
-  create_validation_records = var.create && var.validate && var.create_validation_records
+  create_validation_records = var.create && var.create_validation_records
+
+  validation_records_grouped = var.create ? {
+    for dvo in aws_acm_certificate.cert[0].domain_validation_options :
+    trimprefix(dvo.domain_name, "*.") => {
+      type  = dvo.resource_record_type
+      name  = dvo.resource_record_name
+      value = dvo.resource_record_value
+    }...
+  } : {}
 
   # Wildcard certificates use the same validation records as the base domain, eg.:
   # a certificate for example.com and *.example.com will require a single
   # validation record for example.com
-  validation_options_indices = {
-    for i, domain in var.domains : trimprefix(domain, "*.") => i...
+  validation_records = {
+    for domain, records in local.validation_records_grouped :
+    domain => records[0]
   }
-  validation_options = local.create_validation_records ? {
-    for domain, indices in local.validation_options_indices :
-    domain => aws_acm_certificate.cert[0].domain_validation_options[indices[0]]
-  } : {}
+
   validation_fqdns = local.create_validation_records ? [
     for key, record in aws_route53_record.validation : record.fqdn
   ] : []
 }
 
 resource "aws_route53_record" "validation" {
-  for_each = local.validation_options
+  for_each = local.create_validation_records ? local.validation_records : {}
 
   zone_id = var.hosted_zone_id
-  name    = each.value.resource_record_name
-  type    = each.value.resource_record_type
+  name    = each.value.name
+  type    = each.value.type
   ttl     = "60"
-  records = [each.value.resource_record_value]
+  records = [each.value.value]
 }

--- a/ssl/acm/outputs.tf
+++ b/ssl/acm/outputs.tf
@@ -13,3 +13,8 @@ output "validated_arn" {
   value       = var.create && var.validate ? aws_acm_certificate.cert[0].arn : null
   depends_on  = [aws_acm_certificate_validation.cert]
 }
+
+output "validation_records" {
+  description = "DNS validation records, in cases where you want to manually create them"
+  value       = local.validation_records
+}

--- a/ssl/acm/variables.tf
+++ b/ssl/acm/variables.tf
@@ -12,6 +12,7 @@ variable "domains" {
 variable "hosted_zone_id" {
   description = "Route53 hosted zone id for ACM domain ownership validation"
   type        = string
+  default     = null
 }
 
 variable "tags" {

--- a/ssl/acm/variables.tf
+++ b/ssl/acm/variables.tf
@@ -39,3 +39,9 @@ EOF
   type        = bool
   default     = true
 }
+
+variable "validation_record_fqdns" {
+  description = "When `create_validation_records` is `false` you can pass a list of `aws_route53_record.*.fqdn` to make sure validation checks don't start before the records are created."
+  type        = list(string)
+  default     = null
+}

--- a/ssl/acm/versions.tf
+++ b/ssl/acm/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws = ">= 2.40.0"
+    aws = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
- [x] Added support for aws provider 3.x, which changed the type of `domain_validation_options`
- [x] Added `validation_records` output so you can manually create the records
- [x] Added `validation_record_fqdns` input in case you want to manually create DNS records using terraform, eg. using a different provider
- [x] Made `hosted_zone_id` input optional, since it's only needed when `create_validation_records` is `true`

**Breaking changes**
- [x] `ssl/acm` now requires aws provider 3.x

