### PR TITLE
feat(ecs): added enable_dns_support and enable_dns_hostnames variables

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -53,6 +53,14 @@ Based on [AWS reference architecture](https://github.com/aws-samples/ecs-refarch
 
     Should resources be created
 
+* `enable_dns_hostnames` (`bool`, default: `false`)
+
+    Enable/disable DNS hostnames in the VPC
+
+* `enable_dns_support` (`bool`, default: `true`)
+
+    Enable/disable DNS support in the VPC
+
 * `environment` (`string`, required)
 
     Kebab-cased environment name, eg. development, staging, production.

--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -8,6 +8,8 @@ module "network" {
   availability_zones_count = var.availability_zones_count
   nat_instance             = var.nat_instance
   nat_instance_type        = var.nat_instance_type
+  enable_dns_support       = var.enable_dns_support
+  enable_dns_hostnames     = var.enable_dns_hostnames
   tags                     = var.tags
 }
 

--- a/ecs/network/README.md
+++ b/ecs/network/README.md
@@ -32,6 +32,14 @@ Creates networking resources needed for a standard ECS cluster setup:
 
     Should resources be created
 
+* `enable_dns_hostnames` (`bool`, default: `false`)
+
+    Enable/disable DNS hostnames in the VPC
+
+* `enable_dns_support` (`bool`, default: `true`)
+
+    Enable/disable DNS support in the VPC
+
 * `environment` (`string`, required)
 
     Kebab-cased environment name, eg. development, staging, production.

--- a/ecs/network/main.tf
+++ b/ecs/network/main.tf
@@ -55,6 +55,9 @@ resource "aws_vpc" "cloud" {
 
   cidr_block = local.vpc_block
   tags       = local.tags
+
+  enable_dns_support   = var.enable_dns_support
+  enable_dns_hostnames = var.enable_dns_hostnames
 }
 
 resource "aws_internet_gateway" "gateway" {

--- a/ecs/network/variables.tf
+++ b/ecs/network/variables.tf
@@ -43,3 +43,14 @@ variable "nat_instance_type" {
   default     = "t3.nano"
 }
 
+variable "enable_dns_support" {
+  description = "Enable/disable DNS support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_hostnames" {
+  description = "Enable/disable DNS hostnames in the VPC"
+  type        = bool
+  default     = false
+}

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -43,3 +43,14 @@ variable "nat_instance_type" {
   default     = "t3.nano"
 }
 
+variable "enable_dns_support" {
+  description = "Enable/disable DNS support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_hostnames" {
+  description = "Enable/disable DNS hostnames in the VPC"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- [x] Added `enable_dns_support` variable to enable or disable VPC DNS
- [x] Added `enable_dns_hostnames` variable to enable or disable VPC assigned hostnames, required for eg. EFS