### PR TITLE
feat: added ssl policy variables to cloudfront and spa

### DIFF
--- a/cloudfront/README.md
+++ b/cloudfront/README.md
@@ -107,6 +107,10 @@ AWS Cloudfront distribution
 
     AWS S3 buckets proxied by this distribution
 
+* `ssl_policy` (`string`, default: `"TLSv1.2_2019"`)
+
+    Cloudfront SSL policy, used only when `certificate_arn` is provided. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html
+
 * `tags` (`map(string)`, default: `{}`)
 
     Tags to add to resources

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -23,7 +23,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = var.certificate_arn != null ? "sni-only" : null
-    minimum_protocol_version = var.certificate_arn == null ? null : var.ssl_policy
+    minimum_protocol_version = var.certificate_arn != null ? var.ssl_policy : null
   }
 
   restrictions {

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -21,8 +21,9 @@ resource "aws_cloudfront_distribution" "distribution" {
   viewer_certificate {
     cloudfront_default_certificate = var.certificate_arn == null
 
-    acm_certificate_arn = var.certificate_arn
-    ssl_support_method  = var.certificate_arn != null ? "sni-only" : null
+    acm_certificate_arn      = var.certificate_arn
+    ssl_support_method       = var.certificate_arn != null ? "sni-only" : null
+    minimum_protocol_version = var.certificate_arn == null ? null : var.ssl_policy
   }
 
   restrictions {

--- a/cloudfront/variables.tf
+++ b/cloudfront/variables.tf
@@ -22,6 +22,12 @@ variable "certificate_arn" {
   default     = null
 }
 
+variable "ssl_policy" {
+  description = "Cloudfront SSL policy, used only when `certificate_arn` is provided. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html"
+  type        = string
+  default     = "TLSv1.2_2019"
+}
+
 variable "price_class" {
   # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PriceClass.html
   # https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DistributionConfig.html#cloudfront-Type-DistributionConfig-PriceClass

--- a/spa/README.md
+++ b/spa/README.md
@@ -47,6 +47,10 @@ Module creates:
 
     CloudFront price class, which specifies where the distribution should be replicated, one of: PriceClass_100, PriceClass_200, PriceClass_All
 
+* `cloudfront_ssl_policy` (`string`, default: `"TLSv1.2_2019"`)
+
+    Cloudfront SSL policy, used only when `certificate_arn` is provided. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html
+
 * `create` (`bool`, default: `true`)
 
     Should resources be created

--- a/spa/main.tf
+++ b/spa/main.tf
@@ -256,7 +256,7 @@ resource "aws_cloudfront_distribution" "assets" {
 
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = var.certificate_arn != null ? "sni-only" : null
-    minimum_protocol_version = var.certificate_arn == null ? null : var.cloudfront_ssl_policy
+    minimum_protocol_version = var.certificate_arn != null ? var.cloudfront_ssl_policy : null
   }
 
   tags = local.tags

--- a/spa/main.tf
+++ b/spa/main.tf
@@ -254,8 +254,9 @@ resource "aws_cloudfront_distribution" "assets" {
   viewer_certificate {
     cloudfront_default_certificate = var.certificate_arn == null
 
-    acm_certificate_arn = var.certificate_arn
-    ssl_support_method  = var.certificate_arn != null ? "sni-only" : null
+    acm_certificate_arn      = var.certificate_arn
+    ssl_support_method       = var.certificate_arn != null ? "sni-only" : null
+    minimum_protocol_version = var.certificate_arn == null ? null : var.cloudfront_ssl_policy
   }
 
   tags = local.tags

--- a/spa/variables.tf
+++ b/spa/variables.tf
@@ -38,6 +38,12 @@ variable "certificate_arn" {
   default     = null
 }
 
+variable "cloudfront_ssl_policy" {
+  description = "Cloudfront SSL policy, used only when `certificate_arn` is provided. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html"
+  type        = string
+  default     = "TLSv1.2_2019"
+}
+
 variable "static_path" {
   description = "Base path for static assets"
   type        = string


### PR DESCRIPTION
- [x] Added `cloudfront_ssl_policy` variable to `spa` module
- [x] Added `ssl_policy` variable to `cloudfront` module
- [x] Set the default policy to TLSv1.2_2019

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html