### PR TITLE
fix(ses): invalid event destination default value

### DIFF
--- a/ses/domain/main.tf
+++ b/ses/domain/main.tf
@@ -186,6 +186,6 @@ resource "aws_ses_event_destination" "metrics" {
   cloudwatch_destination {
     value_source   = "messageTag"
     dimension_name = "ses:from-domain"
-    default_value  = local.domain
+    default_value  = "default"
   }
 }


### PR DESCRIPTION
Fixes

```
Error: invalid value for cloudwatch_destination.0.default_value (must contain only alphanumeric, underscore, and hyphen characters)
```
