### PR TITLE
feat!(cloudfront/origin/s3): removed bucket_regional_domain_name

### DIFF
--- a/cloudfront/examples/basic/main.tf
+++ b/cloudfront/examples/basic/main.tf
@@ -23,8 +23,8 @@ resource "aws_s3_bucket_object" "index" {
 }
 
 module "origin_bucket" {
-  source                      = "./../../origin/s3"
-  bucket_regional_domain_name = aws_s3_bucket.bucket.bucket_regional_domain_name
+  source = "./../../origin/s3"
+  bucket = aws_s3_bucket.bucket.bucket
 }
 
 # 2. Create cloudfront behaviors, which specify how paths are handled and cached

--- a/cloudfront/examples/basic_auth/main.tf
+++ b/cloudfront/examples/basic_auth/main.tf
@@ -31,8 +31,8 @@ resource "aws_s3_bucket_object" "assetlinks" {
 }
 
 module "origin_bucket" {
-  source                      = "./../../origin/s3"
-  bucket_regional_domain_name = aws_s3_bucket.bucket.bucket_regional_domain_name
+  source = "./../../origin/s3"
+  bucket = aws_s3_bucket.bucket.bucket
 }
 
 # 2. Create cloudfront behaviors, which specify how paths are handled and cached, eg.:

--- a/cloudfront/examples/single_page_app/main.tf
+++ b/cloudfront/examples/single_page_app/main.tf
@@ -23,8 +23,8 @@ resource "aws_s3_bucket_object" "index" {
 }
 
 module "origin_bucket" {
-  source                      = "./../../origin/s3"
-  bucket_regional_domain_name = aws_s3_bucket.bucket.bucket_regional_domain_name
+  source = "./../../origin/s3"
+  bucket = aws_s3_bucket.bucket.bucket
 }
 
 # 2. Create cloudfront behaviors, which specify how paths are handled and cached

--- a/cloudfront/origin/s3/README.md
+++ b/cloudfront/origin/s3/README.md
@@ -13,13 +13,9 @@ S3 origin factory for the `cloudfront` module
 
 ## Inputs
 
-* `bucket` (`string`, default: `null`)
+* `bucket` (`string`, required)
 
-    S3 bucket name. Either `bucket` or `bucket_regional_domain_name` is required. The bucket domain will be fetched using `data.aws_s3_bucket`.
-
-* `bucket_regional_domain_name` (`string`, default: `null`)
-
-    S3 bucket domain. Either `bucket` or `bucket_regional_domain_name` is required. Disables fetching the bucket using `data.aws_s3_bucket`.
+    S3 bucket name.
 
 * `create` (`bool`, default: `true`)
 

--- a/cloudfront/origin/s3/main.tf
+++ b/cloudfront/origin/s3/main.tf
@@ -1,4 +1,11 @@
-data "aws_s3_bucket" "bucket" {
-  count  = var.create && var.bucket_regional_domain_name == null ? 1 : 0
-  bucket = var.bucket
+data "aws_region" "current" {
+  count = var.create ? 1 : 0
+}
+
+locals {
+  domain = (
+    var.create ?
+    "${var.bucket}.s3.${data.aws_region.current[0].name}.amazonaws.com" :
+    ""
+  )
 }

--- a/cloudfront/origin/s3/outputs.tf
+++ b/cloudfront/origin/s3/outputs.tf
@@ -1,6 +1,6 @@
 output "domain" {
   description = "S3 bucket domain"
-  value       = var.create && var.bucket_regional_domain_name == null ? data.aws_s3_bucket.bucket[0].bucket_regional_domain_name : var.bucket_regional_domain_name
+  value       = local.domain
 }
 
 output "path" {

--- a/cloudfront/origin/s3/variables.tf
+++ b/cloudfront/origin/s3/variables.tf
@@ -5,15 +5,8 @@ variable "create" {
 }
 
 variable "bucket" {
-  description = "S3 bucket name. Either `bucket` or `bucket_regional_domain_name` is required. The bucket domain will be fetched using `data.aws_s3_bucket`."
+  description = "S3 bucket name."
   type        = string
-  default     = null
-}
-
-variable "bucket_regional_domain_name" {
-  description = "S3 bucket domain. Either `bucket` or `bucket_regional_domain_name` is required. Disables fetching the bucket using `data.aws_s3_bucket`."
-  type        = string
-  default     = null
 }
 
 variable "path" {
@@ -27,4 +20,3 @@ variable "headers" {
   type        = map(string)
   default     = {}
 }
-


### PR DESCRIPTION
BREAKING CHANGES:
- removed `bucket_regional_domain_name` variable

Bucket regional domain name is now built using a simple string interpolation. Using `bucket_regional_domain_name` for buckets that should be created in the same terraform apply caused errors that `count` cannot be computed at plan time.