### PR TITLE
fix(cloudfront/lambda): default timeout exceeds cloudfront maximum for viewer events

### DIFF
--- a/cloudfront/lambda/README.md
+++ b/cloudfront/lambda/README.md
@@ -42,6 +42,14 @@ AWS Lambda middleware for AWS CloudFront
 
     Tags to add to resources that support them
 
+* `timeout` (`number`, default: `5`)
+
+    The amount of time your Lambda Function has to run in seconds.
+
+    Maximum of 5 for viewer events, 30 for origin events.
+    https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-requirements-see-limits
+
+
 
 
 ## Outputs

--- a/cloudfront/lambda/main.tf
+++ b/cloudfront/lambda/main.tf
@@ -9,6 +9,6 @@ module "lambda" {
   handler = var.handler
   runtime = var.runtime
 
-  timeout                = 30
+  timeout                = var.timeout
   assume_role_principals = ["edgelambda.amazonaws.com"]
 }

--- a/cloudfront/lambda/response_headers/main.tf
+++ b/cloudfront/lambda/response_headers/main.tf
@@ -27,6 +27,6 @@ module "lambda" {
 
   handler                = "index.handler"
   runtime                = "nodejs12.x"
-  timeout                = 30
+  timeout                = 5
   assume_role_principals = ["edgelambda.amazonaws.com"]
 }

--- a/cloudfront/lambda/variables.tf
+++ b/cloudfront/lambda/variables.tf
@@ -37,3 +37,14 @@ variable "include_body" {
   type        = bool
   default     = false
 }
+
+variable "timeout" {
+  description = <<EOT
+The amount of time your Lambda Function has to run in seconds.
+
+    Maximum of 5 for viewer events, 30 for origin events.
+    https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-requirements-see-limits
+EOT
+  type        = number
+  default     = 5
+}


### PR DESCRIPTION
- [x] Changed default timeout for `cloudfront/lamdba` to 5s from 30s, so it matches viewer event [lambda@edge requirements](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-requirements-see-limits)