### PR TITLE
docs: marked all terraform-docs generated sections with prettier-ignore

### DIFF
--- a/.plop/module/README.md
+++ b/.plop/module/README.md
@@ -2,6 +2,7 @@
 
 <!-- TODO: {{ path }} description -->
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -36,3 +37,4 @@ No resources.
 | <a name="output_metrics"></a> [metrics](#output\_metrics) | Cloudwatch monitoring metrics |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/README.md
+++ b/cloudfront/README.md
@@ -2,6 +2,7 @@
 
 AWS Cloudfront distribution
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -59,3 +60,4 @@ No modules.
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets |
 | <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | Route 53 zone ID that can be used to route an Alias Resource Record Set to. |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/behavior/README.md
+++ b/cloudfront/behavior/README.md
@@ -2,6 +2,7 @@
 
 Behavior factory for the `cloudfront` module
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -57,3 +58,4 @@ No resources.
 | <a name="output_viewer_request_lambda"></a> [viewer\_request\_lambda](#output\_viewer\_request\_lambda) | Lambda function to invoke when CloudFront receives a request |
 | <a name="output_viewer_response_lambda"></a> [viewer\_response\_lambda](#output\_viewer\_response\_lambda) | Lambda function to invoke before CloudFront returns a response |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/lambda/README.md
+++ b/cloudfront/lambda/README.md
@@ -2,6 +2,7 @@
 
 AWS Lambda middleware for AWS CloudFront
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -47,3 +48,4 @@ No resources.
 | <a name="output_metrics"></a> [metrics](#output\_metrics) | Cloudwatch monitoring metrics |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/lambda/basic_auth/README.md
+++ b/cloudfront/lambda/basic_auth/README.md
@@ -2,6 +2,7 @@
 
 Basic authentication middleware for AWS CloudFront
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -41,3 +42,4 @@ No resources.
 | <a name="output_metrics"></a> [metrics](#output\_metrics) | Cloudwatch monitoring metrics |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/lambda/pull_request_router/README.md
+++ b/cloudfront/lambda/pull_request_router/README.md
@@ -2,6 +2,7 @@
 
 Pull request router for AWS CloudFront. Serves the right `index.html` based on a path prefix, by default `/PR-#/`. Useful for SPA preview environments.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -41,3 +42,4 @@ No resources.
 | <a name="output_metrics"></a> [metrics](#output\_metrics) | Cloudwatch monitoring metrics |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/lambda/response_headers/README.md
+++ b/cloudfront/lambda/response_headers/README.md
@@ -10,6 +10,7 @@ If you attach this lambda to the origin response hook keep in mind that cloudfro
 
 Consult the [example](../../examples/response_headers) for how it could be done by terraform using a `null_resource` which uses AWS CLI to invalidate the cache whenever the lambda version changes.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -50,3 +51,4 @@ No resources.
 | <a name="output_metrics"></a> [metrics](#output\_metrics) | Cloudwatch monitoring metrics |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/origin/http/README.md
+++ b/cloudfront/origin/http/README.md
@@ -2,6 +2,7 @@
 
 HTTPS origin factory for the `cloudfront` module
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -39,3 +40,4 @@ No resources.
 | <a name="output_path"></a> [path](#output\_path) | Path where the origin is hosted |
 | <a name="output_port"></a> [port](#output\_port) | Port on which the origin listens for HTTP/HTTPS requests |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/origin/s3/README.md
+++ b/cloudfront/origin/s3/README.md
@@ -2,6 +2,7 @@
 
 S3 origin factory for the `cloudfront` module
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -42,3 +43,4 @@ No modules.
 | <a name="output_headers"></a> [headers](#output\_headers) | Additional headers to pass to S3 |
 | <a name="output_path"></a> [path](#output\_path) | Base S3 object path |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudfront/origin/s3/bucket_policy_document/README.md
+++ b/cloudfront/origin/s3/bucket_policy_document/README.md
@@ -2,6 +2,7 @@
 
 S3 bucket policy to allow access from a cloudfront distribution
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -39,3 +40,4 @@ No modules.
 |------|-------------|
 | <a name="output_json"></a> [json](#output\_json) | Bucket policy JSON document |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/alarm/README.md
+++ b/cloudwatch/alarm/README.md
@@ -1,5 +1,6 @@
 # cloudwatch/alarm
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -45,3 +46,4 @@ No modules.
 | <a name="output_id"></a> [id](#output\_id) | Alarm healthcheck id |
 | <a name="output_name"></a> [name](#output\_name) | Alarm name |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/alarm_widget/README.md
+++ b/cloudwatch/alarm_widget/README.md
@@ -4,6 +4,7 @@ Prepares an alarm widget object for `cloudwatch/dashboard`
 
 https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html#CloudWatch-Dashboard-Properties-Widgets-Structure
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -44,3 +45,4 @@ No resources.
 | <a name="output_properties"></a> [properties](#output\_properties) | Widget properties |
 | <a name="output_type"></a> [type](#output\_type) | Widget type |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/annotation/README.md
+++ b/cloudwatch/annotation/README.md
@@ -2,6 +2,7 @@
 
 Prepares an annotation structure for widget modules.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -41,3 +42,4 @@ No resources.
 | <a name="output_is_horizontal"></a> [is\_horizontal](#output\_is\_horizontal) | Whether this is a horizontal annotation |
 | <a name="output_is_vertical"></a> [is\_vertical](#output\_is\_vertical) | Whether this is a vertical annotation |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/consts/README.md
+++ b/cloudwatch/consts/README.md
@@ -2,6 +2,7 @@
 
 Common cloudwatch-related constants, like the color palette cloudwatch uses by default.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -31,3 +32,4 @@ No inputs.
 |------|-------------|
 | <a name="output_colors"></a> [colors](#output\_colors) | Cloudwatch default color palette |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/dashboard/README.md
+++ b/cloudwatch/dashboard/README.md
@@ -2,6 +2,7 @@
 
 Creates a dashboard in cloudwatch with the given widgets.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -46,3 +47,4 @@ No modules.
 | <a name="output_name"></a> [name](#output\_name) | Dashboard name |
 | <a name="output_url"></a> [url](#output\_url) | Dashboard URL |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/metric/README.md
+++ b/cloudwatch/metric/README.md
@@ -1,5 +1,6 @@
 # cloudwatch/metric
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -44,3 +45,4 @@ No resources.
 | <a name="output_period"></a> [period](#output\_period) | Metric aggregation period in seconds |
 | <a name="output_stat"></a> [stat](#output\_stat) | Metric aggregation function |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/metric/many/README.md
+++ b/cloudwatch/metric/many/README.md
@@ -2,6 +2,7 @@
 
 Same as [cloudwatch/metric](./..) but allows for creating many metrics using a single module
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -37,3 +38,4 @@ No resources.
 | <a name="output_out"></a> [out](#output\_out) | List of [cloudwatch/metric](./..) outputs |
 | <a name="output_out_map"></a> [out\_map](#output\_out\_map) | Map of [cloudwatch/metric](./..) outputs |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/metric_expression/README.md
+++ b/cloudwatch/metric_expression/README.md
@@ -1,5 +1,6 @@
 # cloudwatch/metric_expression
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -36,3 +37,4 @@ No resources.
 | <a name="output_id"></a> [id](#output\_id) | Metric id to use in expressions |
 | <a name="output_label"></a> [label](#output\_label) | Human-friendly metric description |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/metric_expression/many/README.md
+++ b/cloudwatch/metric_expression/many/README.md
@@ -2,6 +2,7 @@
 
 Same as [cloudwatch/metric_expression](./..) but allows for creating many metrics using a single module
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -37,3 +38,4 @@ No resources.
 | <a name="output_out"></a> [out](#output\_out) | List of [cloudwatch/metric\_expression](./..) outputs |
 | <a name="output_out_map"></a> [out\_map](#output\_out\_map) | Map of [cloudwatch/metric\_expression](./..) outputs |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/cloudwatch/metric_widget/README.md
+++ b/cloudwatch/metric_widget/README.md
@@ -4,6 +4,7 @@ Prepares a metric widget object for `cloudwatch/dashboard`
 
 https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html#CloudWatch-Dashboard-Properties-Widgets-Structure
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -55,3 +56,4 @@ No modules.
 | <a name="output_properties"></a> [properties](#output\_properties) | Widget properties |
 | <a name="output_type"></a> [type](#output\_type) | Widget type |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -34,6 +34,7 @@ Based on [AWS reference architecture](https://github.com/aws-samples/ecs-refarch
 
   Creates an ECS task definition
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -127,3 +128,4 @@ Based on [AWS reference architecture](https://github.com/aws-samples/ecs-refarch
 | <a name="output_web_service_role_name"></a> [web\_service\_role\_name](#output\_web\_service\_role\_name) | ECS web service task role name |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | ECS cluster Cloudwatch dashboard widgets, see [widgets.tf](./widgets.tf) for details |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/access/README.md
+++ b/ecs/access/README.md
@@ -2,6 +2,7 @@
 
 Creates IAM resources needed to run host instances and services in the ECS cluster.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -57,3 +58,4 @@ No modules.
 | <a name="output_web_service_role_arn"></a> [web\_service\_role\_arn](#output\_web\_service\_role\_arn) | ECS web service task role ARN |
 | <a name="output_web_service_role_name"></a> [web\_service\_role\_name](#output\_web\_service\_role\_name) | ECS web service task role name |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/host_group/README.md
+++ b/ecs/host_group/README.md
@@ -2,6 +2,7 @@
 
 Creates an auto-scaling group of EC2 instances which will join the given ECS cluster.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -86,3 +87,4 @@ Creates an auto-scaling group of EC2 instances which will join the given ECS clu
 | <a name="output_metrics"></a> [metrics](#output\_metrics) | Cloudwatch metrics, see [metrics.tf](./metrics.tf) |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets, see [widgets.tf](./widgets.tf) |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/network/README.md
+++ b/ecs/network/README.md
@@ -11,6 +11,7 @@ Creates networking resources needed for a standard ECS cluster setup:
 
 - [ ] S3 bucket for ALB Logs
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -151,3 +152,4 @@ Creates networking resources needed for a standard ECS cluster setup:
 | <a name="output_vpc_block"></a> [vpc\_block](#output\_vpc\_block) | The CIDR block of the VPC |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/network/domain/README.md
+++ b/ecs/network/domain/README.md
@@ -2,6 +2,7 @@
 
 Creates a Route53 record that points to the cluster load balancer. If `https_listener_arn` is provided will also attach a certificate to the https listener.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -49,3 +50,4 @@ Creates a Route53 record that points to the cluster load balancer. If `https_lis
 |------|-------------|
 | <a name="output_certificate_arn"></a> [certificate\_arn](#output\_certificate\_arn) | ACM certificate ARN that was added to the https listener |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/repository/README.md
+++ b/ecs/repository/README.md
@@ -2,6 +2,7 @@
 
 Creates an ECR repository and a policy for CI which allows push/pull access.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -48,3 +49,4 @@ No modules.
 | <a name="output_registry_id"></a> [registry\_id](#output\_registry\_id) | ECR registry id where the repository was created |
 | <a name="output_url"></a> [url](#output\_url) | ECR repository URL |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/services/statsd/README.md
+++ b/ecs/services/statsd/README.md
@@ -2,6 +2,7 @@
 
 Adds a statsd server, using cloudwatch agent, to each ECS instance
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -59,3 +60,4 @@ No modules.
 | <a name="output_task_arn"></a> [task\_arn](#output\_task\_arn) | Task definition ARN |
 | <a name="output_task_family"></a> [task\_family](#output\_task\_family) | Task definition family |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/services/web/README.md
+++ b/ecs/services/web/README.md
@@ -2,6 +2,7 @@
 
 Creates an ECS service exposed to the internet using an Application Load Balancer.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -91,3 +92,4 @@ Creates an ECS service exposed to the internet using an Application Load Balance
 | <a name="output_target_group_name"></a> [target\_group\_name](#output\_target\_group\_name) | Load balancer target group name |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets, see [widgets.tf](./widgets.tf) |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/services/worker/README.md
+++ b/ecs/services/worker/README.md
@@ -2,6 +2,7 @@
 
 Creates an ECS service for background workers
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -58,3 +59,4 @@ Creates an ECS service for background workers
 | <a name="output_metrics"></a> [metrics](#output\_metrics) | Cloudwatch metrics, see [metrics.tf](./metrics.tf) |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets, see [widgets.tf](./widgets.tf) |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/task/README.md
+++ b/ecs/task/README.md
@@ -29,6 +29,7 @@ There's 3 ways to specify the container image:
 
 We recommend creating the task definition using `image` or `image_name` + `image_tag` and then switching to just `image_name` to allow for external updates.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -94,3 +95,4 @@ We recommend creating the task definition using `image` or `image_name` + `image
 | <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | CloudWatch log group name |
 | <a name="output_revision"></a> [revision](#output\_revision) | Task definition revision |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/task/container_definition/README.md
+++ b/ecs/task/container_definition/README.md
@@ -2,6 +2,7 @@
 
 Creates a container definition that can be provided to a task definition
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -46,3 +47,4 @@ No resources.
 | <a name="output_definition"></a> [definition](#output\_definition) | container definition |
 | <a name="output_json"></a> [json](#output\_json) | container definition JSON |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ecs/task/log_group/README.md
+++ b/ecs/task/log_group/README.md
@@ -2,6 +2,7 @@
 
 Creates a CloudWatch log group for a container and outputs container logging configuration.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -48,3 +49,4 @@ No modules.
 | <a name="output_container_config_json"></a> [container\_config\_json](#output\_container\_config\_json) | Container definition logging configuration JSON |
 | <a name="output_name"></a> [name](#output\_name) | CloudWatch log group name |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/elasticache/redis/README.md
+++ b/elasticache/redis/README.md
@@ -2,6 +2,7 @@
 
 Creates an Elasticache Redis cluster
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -57,3 +58,4 @@ No modules.
 | <a name="output_url"></a> [url](#output\_url) | First Redis instance connection url |
 | <a name="output_urls"></a> [urls](#output\_urls) | Redis connection urls |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/iam/user/README.md
+++ b/iam/user/README.md
@@ -2,6 +2,7 @@
 
 Creates an IAM user along with an access key and attaches the given policies to it.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -47,3 +48,4 @@ No modules.
 | <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | User's secret access key |
 | <a name="output_ses_smtp_password"></a> [ses\_smtp\_password](#output\_ses\_smtp\_password) | User's secret access key converted into an SES SMTP password |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/iam/user/set/README.md
+++ b/iam/user/set/README.md
@@ -2,6 +2,7 @@
 
 Creates a set of IAM users with access keys
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -43,3 +44,4 @@ No modules.
 |------|-------------|
 | <a name="output_users"></a> [users](#output\_users) | Map of created users |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/lambda/layer/README.md
+++ b/lambda/layer/README.md
@@ -2,6 +2,7 @@
 
 Creates an AWS Lambda Layer that can be attached to a AWS Lambda Function
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -52,3 +53,4 @@ Creates an AWS Lambda Layer that can be attached to a AWS Lambda Function
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | The ARN identifying the Lambda Layer Version |
 | <a name="output_version"></a> [version](#output\_version) | Latest published version of the Lambda Layer |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/lambda/trigger/schedule/README.md
+++ b/lambda/trigger/schedule/README.md
@@ -2,6 +2,7 @@
 
 Sets up lambda triggering on schedule using a Cloudwatch event rule.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -47,3 +48,4 @@ No modules.
 | <a name="output_rule_arn"></a> [rule\_arn](#output\_rule\_arn) | Cloudwatch event rule ARN |
 | <a name="output_rule_name"></a> [rule\_name](#output\_rule\_name) | Cloudwatch event rule name |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/meta/README.md
+++ b/meta/README.md
@@ -28,6 +28,7 @@ Actual project infrastructure state is separate from the meta state, to configur
 terraform output -module NAME_OF_META_MODULE backend_config
 ```
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -88,3 +89,4 @@ No modules.
 | <a name="output_provider_aws_alias_config_template"></a> [provider\_aws\_alias\_config\_template](#output\_provider\_aws\_alias\_config\_template) | Terraform AWS provider block template for defining aliases, accepts alias and region variables |
 | <a name="output_provider_aws_config"></a> [provider\_aws\_config](#output\_provider\_aws\_config) | Terraform AWS provider block |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/meta/aws_account/README.md
+++ b/meta/aws_account/README.md
@@ -2,6 +2,7 @@
 
 Creates a sub-account for a given project's, environment's resources.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -45,3 +46,4 @@ No modules.
 | <a name="output_provider_config"></a> [provider\_config](#output\_provider\_config) | Terraform AWS provider block |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | IAM role ARN for root account administrators to manage the member account |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/rds/postgres/README.md
+++ b/rds/postgres/README.md
@@ -2,6 +2,7 @@
 
 Creates an RDS PostgreSQL database instance
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -71,3 +72,4 @@ Creates an RDS PostgreSQL database instance
 | <a name="output_url"></a> [url](#output\_url) | DB connection url |
 | <a name="output_username"></a> [username](#output\_username) | DB master username |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/rds/postgres/management_lambda/README.md
+++ b/rds/postgres/management_lambda/README.md
@@ -15,6 +15,7 @@ Remember to always run `npm run build` before committing any changes in `src`, s
 >
 > Figure out a better way to handle this or at least add a CI step to verify `dist` is up-to-date.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -62,3 +63,4 @@ Remember to always run `npm run build` before committing any changes in `src`, s
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | The ARN identifying the Lambda Function Version |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | Security group id |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/redirect/README.md
+++ b/redirect/README.md
@@ -9,6 +9,7 @@ Module creates:
 - AWS S3 bucket for redirection configuration
 - AWS CloudFront distribution for SSL termination and geographical distribution
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -63,3 +64,4 @@ No modules.
 | <a name="output_distribution_url"></a> [distribution\_url](#output\_distribution\_url) | URL of the created redirection CloudFront distribution, eg. https://d604721fxaaqy9.cloudfront.net. |
 | <a name="output_distribution_zone_id"></a> [distribution\_zone\_id](#output\_distribution\_zone\_id) | The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to. |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ses/domain/README.md
+++ b/ses/domain/README.md
@@ -13,6 +13,7 @@ Registers a domain with AWS SES and verifies it
 >
 > Module assumes you add additional resources to setup receiving emails with SES or provide an address to some other SMTP server which handles incoming emails.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -100,3 +101,4 @@ Registers a domain with AWS SES and verifies it
 | <a name="output_spf_record"></a> [spf\_record](#output\_spf\_record) | SPF record which you should include in the domain's TXT record in case you specified `spf = false` |
 | <a name="output_widgets"></a> [widgets](#output\_widgets) | Cloudwatch dashboard widgets, see [widgets.tf](./widgets.tf) for details |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/spa/README.md
+++ b/spa/README.md
@@ -15,6 +15,7 @@ Module creates:
 - AWS IAM role for adding middleware Lambda@Edge functions
 - Optional basic auth and pull request routing Lambdas
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -89,3 +90,4 @@ Module creates:
 | <a name="output_distribution_url"></a> [distribution\_url](#output\_distribution\_url) | URL of the created assets CloudFront distribution, eg. https://d604721fxaaqy9.cloudfront.net. |
 | <a name="output_distribution_zone_id"></a> [distribution\_zone\_id](#output\_distribution\_zone\_id) | The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to. |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/spa/ci/README.md
+++ b/spa/ci/README.md
@@ -6,6 +6,7 @@ Creates an AWS user for CI/CD pipelines which can update the contents of the giv
 >
 > `terraform-modules/spa` now provides an IAM policy which can be used with `terraform-modules/iam/user` to create a CI user
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -51,3 +52,4 @@ No modules.
 | <a name="output_ci_user_arn"></a> [ci\_user\_arn](#output\_ci\_user\_arn) | CI AWS user ARN |
 | <a name="output_ci_user_name"></a> [ci\_user\_name](#output\_ci\_user\_name) | CI AWS user |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/spa/middleware/README.md
+++ b/spa/middleware/README.md
@@ -2,6 +2,7 @@
 
 `spa` internal module which creates a single Lambda@Edge function to be attached to a CloudFront distribution as middleware.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -47,3 +48,4 @@ No modules.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | Lambda ARN |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/spa/middleware_common/README.md
+++ b/spa/middleware_common/README.md
@@ -2,6 +2,7 @@
 
 `spa` internal module which creates common resources needed for CloudFront Lambda@Edge middleware.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -41,3 +42,4 @@ No modules.
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | ARN of the IAM role that should be assumed by middleware Lambdas |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | Name of the IAM role that should be assumed by middleware Lambdas |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/ssl/acm/README.md
+++ b/ssl/acm/README.md
@@ -2,6 +2,7 @@
 
 Creates an SSL certificate using AWS ACM, verifies domain ownership using Route53 and returns it's ARN, so it can be attached to AWS resources, eg. CloudFront.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -49,3 +50,4 @@ No modules.
 | <a name="output_validated_arn"></a> [validated\_arn](#output\_validated\_arn) | ACM certificate ARN, once it's validated |
 | <a name="output_validation_records"></a> [validation\_records](#output\_validation\_records) | DNS validation records, in cases where you want to manually create them |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -2,6 +2,7 @@
 
 Creates resources needed to use a terraform S3 backend with locking
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -51,3 +52,4 @@ No modules.
 | <a name="output_lock_table_name"></a> [lock\_table\_name](#output\_lock\_table\_name) | State lock table name |
 | <a name="output_remote_state_template"></a> [remote\_state\_template](#output\_remote\_state\_template) | terraform\_remote\_state block template |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->

--- a/zip/README.md
+++ b/zip/README.md
@@ -2,6 +2,7 @@
 
 Creates a zip archive with the specified contents.
 
+<!-- prettier-ignore-start -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -49,3 +50,4 @@ No modules.
 | <a name="output_output_sha"></a> [output\_sha](#output\_output\_sha) | The SHA1 checksum of output archive file. |
 | <a name="output_output_size"></a> [output\_size](#output\_output\_size) | The size of the output archive file. |
 <!-- END_TF_DOCS -->
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Added `<!-- prettier-ignore-start -->` and `<!-- prettier-ignore-end -->` comments around documentation generated by terraform-docs, so prettier doesn't try to format it.