### PR TITLE
internal: terraform s3 backend for examples

### DIFF
--- a/.backend/main.tf
+++ b/.backend/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {}
+
+terraform {
+  backend "s3" {
+    key = ".backend"
+  }
+}
+
+module "backend" {
+  source = "./../terraform/backend/s3"
+
+  bucket_name     = "terraform-modules-example-state"
+  lock_table_name = "terraform-modules-example-state-lock"
+
+  tags = {
+    Project     = "terraform-modules"
+    Environment = "example"
+  }
+}

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,17 @@
+# Specify AWS credentials for terraform and AWS CLI
+export AWS_PROFILE=
+export AWS_REGION=eu-west-1
+export AWS_DEFAULT_REGION="$AWS_REGION"
+export AWS_SDK_LOAD_CONFIG=1
+
+# Some examples require a working Route53 hosted zone,
+# eg. for DNS-based certificate validation
+export TF_VAR_zone_domain=
+
+# Common backend configuration for examples
+# Backend resources are defined in .backend
+export TF_CLI_ARGS_init='
+  -backend-config="bucket=terraform-modules-example-state"
+  -backend-config="dynamodb_table=terraform-modules-example-state-lock"
+  -backend-config="encrypt=true"
+'

--- a/.plop/module/example/backend.tf
+++ b/.plop/module/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "{{ path }}"
+  }
+}

--- a/cloudfront/examples/basic/backend.tf
+++ b/cloudfront/examples/basic/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudfront/examples/basic"
+  }
+}

--- a/cloudfront/examples/basic_auth/backend.tf
+++ b/cloudfront/examples/basic_auth/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudfront/examples/basic_auth"
+  }
+}

--- a/cloudfront/examples/response_headers/backend.tf
+++ b/cloudfront/examples/response_headers/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudfront/examples/response_headers"
+  }
+}

--- a/cloudfront/examples/single_page_app/backend.tf
+++ b/cloudfront/examples/single_page_app/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudfront/examples/single_page_app"
+  }
+}

--- a/cloudfront/examples/static_website/backend.tf
+++ b/cloudfront/examples/static_website/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudfront/examples/static_website"
+  }
+}

--- a/cloudwatch/alarm/example/backend.tf
+++ b/cloudwatch/alarm/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudwatch/alarm/example"
+  }
+}

--- a/cloudwatch/alarm_widget/example/backend.tf
+++ b/cloudwatch/alarm_widget/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudwatch/alarm_widget/example"
+  }
+}

--- a/cloudwatch/dashboard/example/backend.tf
+++ b/cloudwatch/dashboard/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudwatch/dashboard/example"
+  }
+}

--- a/cloudwatch/metric_widget/example/backend.tf
+++ b/cloudwatch/metric_widget/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "cloudwatch/metric_widget/example"
+  }
+}

--- a/ecs/example/backend.tf
+++ b/ecs/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "ecs/example"
+  }
+}

--- a/ecs/task/container_definition/example/backend.tf
+++ b/ecs/task/container_definition/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "ecs/task/container_definition/example"
+  }
+}

--- a/ecs/task/example/backend.tf
+++ b/ecs/task/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "ecs/task/example"
+  }
+}

--- a/elasticache/redis/example/backend.tf
+++ b/elasticache/redis/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "elasticache/redis/example"
+  }
+}

--- a/iam/user/example/backend.tf
+++ b/iam/user/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "iam/user/example"
+  }
+}

--- a/iam/user/set/example/backend.tf
+++ b/iam/user/set/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "iam/user/set/example"
+  }
+}

--- a/lambda/examples/basic/backend.tf
+++ b/lambda/examples/basic/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "lambda/examples/basic"
+  }
+}

--- a/lambda/examples/binary/backend.tf
+++ b/lambda/examples/binary/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "lambda/examples/binary"
+  }
+}

--- a/lambda/examples/invoke/backend.tf
+++ b/lambda/examples/invoke/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "lambda/examples/invoke"
+  }
+}

--- a/lambda/examples/vpc/backend.tf
+++ b/lambda/examples/vpc/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "lambda/examples/vpc"
+  }
+}

--- a/lambda/layer/example/backend.tf
+++ b/lambda/layer/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "lambda/layer/example"
+  }
+}

--- a/lambda/trigger/schedule/example/backend.tf
+++ b/lambda/trigger/schedule/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "lambda/trigger/schedule/example"
+  }
+}

--- a/meta/aws_account/example/backend.tf
+++ b/meta/aws_account/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "meta/aws_account/example"
+  }
+}

--- a/meta/example/backend.tf
+++ b/meta/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "meta/example"
+  }
+}

--- a/rds/postgres/example/backend.tf
+++ b/rds/postgres/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "rds/postgres/example"
+  }
+}

--- a/redirect/example/backend.tf
+++ b/redirect/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "redirect/example"
+  }
+}

--- a/ses/domain/example/backend.tf
+++ b/ses/domain/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "ses/domain/example"
+  }
+}

--- a/spa/ci/example/backend.tf
+++ b/spa/ci/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "spa/ci/example"
+  }
+}

--- a/spa/examples/development/backend.tf
+++ b/spa/examples/development/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "spa/examples/development"
+  }
+}

--- a/spa/examples/preview/backend.tf
+++ b/spa/examples/preview/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "spa/examples/preview"
+  }
+}

--- a/spa/examples/production/backend.tf
+++ b/spa/examples/production/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "spa/examples/production"
+  }
+}

--- a/spa/examples/static_website/backend.tf
+++ b/spa/examples/static_website/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "spa/examples/static_website"
+  }
+}

--- a/spa/middleware/example/backend.tf
+++ b/spa/middleware/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "spa/middleware/example"
+  }
+}

--- a/ssl/acm/example/backend.tf
+++ b/ssl/acm/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "ssl/acm/example"
+  }
+}

--- a/terraform/backend/s3/example/backend.tf
+++ b/terraform/backend/s3/example/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "terraform/backend/s3/example"
+  }
+}


### PR DESCRIPTION
We use examples both for documenting and testing modules. Up to now whenever we'd deploy an example the terraform state would be stored locally. This PR adds an S3 backend to all examples, so we don't have to remember which example's state is on which device...