### PR TITLE
feat(ecs/task/role): ensure that the role is not used before policies are attached

### DIFF
--- a/ecs/task/role/outputs.tf
+++ b/ecs/task/role/outputs.tf
@@ -1,9 +1,23 @@
 output "name" {
   description = "Role name"
   value       = var.create ? aws_iam_role.this[0].name : ""
+
+  # Make sure the role is not used before policies are attached
+  depends_on = [
+    aws_iam_role_policy.inline,
+    aws_iam_role_policy_attachment.attachment,
+    aws_iam_role_policy_attachment.execution,
+  ]
 }
 
 output "arn" {
   description = "Role ARN"
   value       = var.create ? aws_iam_role.this[0].arn : ""
+
+  # Make sure the role is not used before policies are attached
+  depends_on = [
+    aws_iam_role_policy.inline,
+    aws_iam_role_policy_attachment.attachment,
+    aws_iam_role_policy_attachment.execution,
+  ]
 }


### PR DESCRIPTION
Added dependencies to `ecs/task/role` outputs that ensure the task is not used before the policies are attached.