### PR TITLE
fix(ecs/task/role): role could be used before policies have been assigned

### DIFF
--- a/ecs/task/role/outputs.tf
+++ b/ecs/task/role/outputs.tf
@@ -1,9 +1,21 @@
 output "name" {
+  depends_on = [
+    aws_iam_role_policy.inline,
+    aws_iam_role_policy_attachment.attachment,
+    aws_iam_role_policy_attachment.execution,
+  ]
+
   description = "Role name"
   value       = var.create ? aws_iam_role.this[0].name : ""
 }
 
 output "arn" {
+  depends_on = [
+    aws_iam_role_policy.inline,
+    aws_iam_role_policy_attachment.attachment,
+    aws_iam_role_policy_attachment.execution,
+  ]
+
   description = "Role ARN"
   value       = var.create ? aws_iam_role.this[0].arn : ""
 }


### PR DESCRIPTION
IAM role created by `ecs/task/role` could have been assigned to an ECS task before policies have been added to the role. This could result in some nasty race conditions, e.g. ECS failing to start a task due to missing permissions.

Added explicit `depends_on` to the `name` and `arn` outputs to ensure policies are assigned before the role is used.