### PR TITLE
feat(ecs/network): support tls provider 4.x, drop support for <3.2

### DIFF
--- a/ecs/network/README.md
+++ b/ecs/network/README.md
@@ -20,7 +20,7 @@ Creates networking resources needed for a standard ECS cluster setup:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12, <2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.40.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.1.2 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 2.0.1 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.2.0 |
 
 ## Providers
 
@@ -28,7 +28,7 @@ Creates networking resources needed for a standard ECS cluster setup:
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.40.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.1.2 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 2.0.1 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.2.0 |
 
 ## Modules
 

--- a/ecs/network/main.tf
+++ b/ecs/network/main.tf
@@ -258,7 +258,6 @@ resource "tls_private_key" "lb_default" {
 resource "tls_self_signed_cert" "lb_default" {
   count = var.create ? 1 : 0
 
-  key_algorithm         = "RSA"
   private_key_pem       = tls_private_key.lb_default[0].private_key_pem
   validity_period_hours = 365 * 24
 

--- a/ecs/network/versions.tf
+++ b/ecs/network/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws  = ">= 2.40.0"
-    tls  = ">= 2.0.1"
+    tls  = ">= 3.2.0"
     null = ">= 2.1.2"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,6 +9,6 @@ terraform {
     archive = "2.1.0"
     null    = "3.1.0"
     random  = "3.1.0"
-    tls     = "3.1.0"
+    tls     = "4.0.4"
   }
 }


### PR DESCRIPTION
TLS provider 4 has removed the `key_algorithm` attribute from `tls_self_signed_cert` resource, which was required before version 3.2. This PR removes this attribute from the `ecs/network` module, so that we can upgrade to the latest TLS provider.