### PR TITLE
feat: enable default server side encryption for S3 buckets

### DIFF
--- a/meta/main.tf
+++ b/meta/main.tf
@@ -71,6 +71,14 @@ resource "aws_s3_bucket" "state" {
   }
 
   tags = local.tags
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_dynamodb_table" "state_lock" {

--- a/redirect/main.tf
+++ b/redirect/main.tf
@@ -17,6 +17,14 @@ resource "aws_s3_bucket" "redirect" {
       }]
     EOF
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "redirect" {

--- a/spa/main.tf
+++ b/spa/main.tf
@@ -39,6 +39,14 @@ resource "aws_s3_bucket" "assets" {
       routing_rules  = var.static_website_routing_rules
     }
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 data "aws_region" "current" {

--- a/terraform/backend/s3/main.tf
+++ b/terraform/backend/s3/main.tf
@@ -9,6 +9,14 @@ resource "aws_s3_bucket" "state" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_dynamodb_table" "state_lock" {


### PR DESCRIPTION
Enabled server side encryption for all buckets in all modules.

AWS has switched on server side encryption by default and for existing buckets, so this was just causing mismatches between states and actual AWS configuration.