### PR TITLE
fix!: nodejs 12.x lambda runtime is no longer supported

### DIFF
--- a/cloudfront/lambda/README.md
+++ b/cloudfront/lambda/README.md
@@ -37,7 +37,7 @@ No resources.
 | <a name="input_include_body"></a> [include\_body](#input\_include\_body) | Whether the lambda requires viewer/origin request body | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Lambda name | `string` | n/a | yes |
 | <a name="input_package_path"></a> [package\_path](#input\_package\_path) | Path where the lambda package will be created.<br>See `zip` `output_path` input for details. | `string` | `null` | no |
-| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda runtime | `string` | `"nodejs12.x"` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda runtime | `string` | `"nodejs18.x"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to resources that support them | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds.<br><br>    Maximum of 5 for viewer events, 30 for origin events.<br>    https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-requirements-see-limits | `number` | `5` | no |
 

--- a/cloudfront/lambda/basic_auth/main.tf
+++ b/cloudfront/lambda/basic_auth/main.tf
@@ -10,5 +10,5 @@ module "middleware" {
     credentials = base64encode(var.credentials)
   })
   handler = "index.handler"
-  runtime = "nodejs12.x"
+  runtime = "nodejs18.x"
 }

--- a/cloudfront/lambda/pull_request_router/main.tf
+++ b/cloudfront/lambda/pull_request_router/main.tf
@@ -8,5 +8,5 @@ module "middleware" {
 
   code    = templatefile("${path.module}/index.js", { path_re = var.path_re })
   handler = "index.handler"
-  runtime = "nodejs12.x"
+  runtime = "nodejs18.x"
 }

--- a/cloudfront/lambda/response_headers/main.tf
+++ b/cloudfront/lambda/response_headers/main.tf
@@ -35,7 +35,7 @@ module "lambda" {
   package_path = module.package.output_path
 
   handler                = "index.handler"
-  runtime                = "nodejs12.x"
+  runtime                = "nodejs18.x"
   timeout                = 5
   assume_role_principals = ["edgelambda.amazonaws.com"]
 }

--- a/cloudfront/lambda/variables.tf
+++ b/cloudfront/lambda/variables.tf
@@ -26,7 +26,7 @@ variable "package_path" {
 variable "runtime" {
   description = "Lambda runtime"
   type        = string
-  default     = "nodejs12.x"
+  default     = "nodejs18.x"
 }
 
 variable "handler" {

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -74,7 +74,7 @@ There's no good workaround for this. You will have to either:
 | <a name="input_package_s3_version"></a> [package\_s3\_version](#input\_package\_s3\_version) | Version number of the S3 object to use | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Additional policy ARNs to attach to the Lambda role | `map(string)` | `{}` | no |
 | <a name="input_publish"></a> [publish](#input\_publish) | Whether to create lambda versions when it's created and on any code or configuration changes.<br>When disabled the only available version will be `$LATEST`. | `bool` | `true` | no |
-| <a name="input_runtime"></a> [runtime](#input\_runtime) | [Runtime](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) | `string` | `"nodejs12.x"` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | [Runtime](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) | `string` | `"nodejs18.x"` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security groups to assign | `list(string)` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet ids to place the lambda in | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to set on resources that support them | `map(string)` | `{}` | no |

--- a/lambda/bin/invoke
+++ b/lambda/bin/invoke
@@ -39,6 +39,7 @@ invoke_response=$(
   --payload "$event" \
   --output json \
   --log-type Tail \
+  --cli-binary-format raw-in-base64-out \
   "$@" \
   "$result"
 )

--- a/lambda/layer/README.md
+++ b/lambda/layer/README.md
@@ -43,7 +43,7 @@ Creates an AWS Lambda Layer that can be attached to a AWS Lambda Function
 | <a name="input_package_path"></a> [package\_path](#input\_package\_path) | Path to the zip that contains the Lambda layer's source. Either `package_path`, `package_s3` or `image` is required. | `string` | `null` | no |
 | <a name="input_package_s3"></a> [package\_s3](#input\_package\_s3) | S3 zip object that contains the Lambda layer's source. Either `package_path` or `package_s3` is required. | <pre>object({<br>    bucket = string<br>    key    = string<br>  })</pre> | `null` | no |
 | <a name="input_package_s3_version"></a> [package\_s3\_version](#input\_package\_s3\_version) | Version number of the S3 object to use | `string` | `null` | no |
-| <a name="input_runtimes"></a> [runtimes](#input\_runtimes) | [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) compatible with this lambda layer | `list(string)` | <pre>[<br>  "nodejs12.x"<br>]</pre> | no |
+| <a name="input_runtimes"></a> [runtimes](#input\_runtimes) | [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) compatible with this lambda layer | `list(string)` | <pre>[<br>  "nodejs18.x"<br>]</pre> | no |
 
 ## Outputs
 

--- a/lambda/layer/variables.tf
+++ b/lambda/layer/variables.tf
@@ -12,7 +12,7 @@ variable "name" {
 variable "runtimes" {
   description = "[Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) compatible with this lambda layer"
   type        = list(string)
-  default     = ["nodejs12.x"]
+  default     = ["nodejs18.x"]
 }
 
 variable "package_path" {

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -108,7 +108,7 @@ variable "file_exclude_patterns" {
 variable "runtime" {
   description = "[Runtime](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime)"
   type        = string
-  default     = "nodejs12.x"
+  default     = "nodejs18.x"
 }
 
 variable "handler" {

--- a/rds/postgres/management_lambda/dist/index.js
+++ b/rds/postgres/management_lambda/dist/index.js
@@ -5,7 +5,7 @@
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 try {
-  var util = __nccwpck_require__(1669);
+  var util = __nccwpck_require__(3837);
   /* istanbul ignore next */
   if (typeof util.inherits !== 'function') throw '';
   module.exports = util.inherits;
@@ -51,14 +51,26 @@ if (typeof Object.create === 'function') {
 
 /***/ }),
 
+/***/ 7078:
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
+
+"use strict";
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+// This is an empty module that is served up when outside of a workerd environment
+// See the `exports` field in package.json
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({});
+//# sourceMappingURL=empty.js.map
+
+/***/ }),
+
 /***/ 8961:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-
-var url = __nccwpck_require__(8835)
-var fs = __nccwpck_require__(5747)
 
 //Parse method copied from https://github.com/brianc/node-postgres
 //Copyright (c) 2010-2014 Brian Carlson (brian.m.carlson@gmail.com)
@@ -68,51 +80,57 @@ var fs = __nccwpck_require__(5747)
 function parse(str) {
   //unix socket
   if (str.charAt(0) === '/') {
-    var config = str.split(' ')
+    const config = str.split(' ')
     return { host: config[0], database: config[1] }
   }
 
-  // url parse expects spaces encoded as %20
-  var result = url.parse(
-    / |%[^a-f0-9]|%[a-f0-9][^a-f0-9]/i.test(str) ? encodeURI(str).replace(/\%25(\d\d)/g, '%$1') : str,
-    true
-  )
-  var config = result.query
-  for (var k in config) {
-    if (Array.isArray(config[k])) {
-      config[k] = config[k][config[k].length - 1]
-    }
+  // Check for empty host in URL
+
+  const config = {}
+  let result
+  let dummyHost = false
+  if (/ |%[^a-f0-9]|%[a-f0-9][^a-f0-9]/i.test(str)) {
+    // Ensure spaces are encoded as %20
+    str = encodeURI(str).replace(/\%25(\d\d)/g, '%$1')
   }
 
-  var auth = (result.auth || ':').split(':')
-  config.user = auth[0]
-  config.password = auth.splice(1).join(':')
+  try {
+    result = new URL(str, 'postgres://base')
+  } catch (e) {
+    // The URL is invalid so try again with a dummy host
+    result = new URL(str.replace('@/', '@___DUMMY___/'), 'postgres://base')
+    dummyHost = true
+  }
 
-  config.port = result.port
+  // We'd like to use Object.fromEntries() here but Node.js 10 does not support it
+  for (const entry of result.searchParams.entries()) {
+    config[entry[0]] = entry[1]
+  }
+
+  config.user = config.user || decodeURIComponent(result.username)
+  config.password = config.password || decodeURIComponent(result.password)
+
   if (result.protocol == 'socket:') {
     config.host = decodeURI(result.pathname)
-    config.database = result.query.db
-    config.client_encoding = result.query.encoding
+    config.database = result.searchParams.get('db')
+    config.client_encoding = result.searchParams.get('encoding')
     return config
   }
+  const hostname = dummyHost ? '' : result.hostname
   if (!config.host) {
     // Only set the host if there is no equivalent query param.
-    config.host = result.hostname
+    config.host = decodeURIComponent(hostname)
+  } else if (hostname && /^%2f/i.test(hostname)) {
+    // Only prepend the hostname to the pathname if it is not a URL encoded Unix socket host.
+    result.pathname = hostname + result.pathname
+  }
+  if (!config.port) {
+    // Only set the port if there is no equivalent query param.
+    config.port = result.port
   }
 
-  // If the host is missing it might be a URL-encoded path to a socket.
-  var pathname = result.pathname
-  if (!config.host && pathname && /^%2f/i.test(pathname)) {
-    var pathnameSplit = pathname.split('/')
-    config.host = decodeURIComponent(pathnameSplit[0])
-    pathname = pathnameSplit.splice(1).join('/')
-  }
-  // result.pathname is not always guaranteed to have a '/' prefix (e.g. relative urls)
-  // only strip the slash if it is present.
-  if (pathname && pathname.charAt(0) === '/') {
-    pathname = pathname.slice(1) || null
-  }
-  config.database = pathname && decodeURI(pathname)
+  const pathname = result.pathname.slice(1) || null
+  config.database = pathname ? decodeURI(pathname) : null
 
   if (config.ssl === 'true' || config.ssl === '1') {
     config.ssl = true
@@ -125,6 +143,9 @@ function parse(str) {
   if (config.sslcert || config.sslkey || config.sslrootcert || config.sslmode) {
     config.ssl = {}
   }
+
+  // Only try to load fs if we expect to read from the disk
+  const fs = config.sslcert || config.sslkey || config.sslrootcert ? __nccwpck_require__(7147) : null
 
   if (config.sslcert) {
     config.ssl.cert = fs.readFileSync(config.sslcert).toString()
@@ -619,7 +640,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Parser = void 0;
 const messages_1 = __nccwpck_require__(6359);
 const buffer_reader_1 = __nccwpck_require__(320);
-const assert_1 = __importDefault(__nccwpck_require__(2357));
+const assert_1 = __importDefault(__nccwpck_require__(9491));
 // every message is prefixed with a single bye
 const CODE_LENGTH = 1;
 // every message has an int32 length which includes itself but does
@@ -1762,17 +1783,16 @@ module.exports = {
 "use strict";
 
 
-var EventEmitter = __nccwpck_require__(8614).EventEmitter
-var util = __nccwpck_require__(1669)
+var EventEmitter = (__nccwpck_require__(2361).EventEmitter)
 var utils = __nccwpck_require__(6419)
-var sasl = __nccwpck_require__(9481)
-var pgPass = __nccwpck_require__(9713)
+var sasl = __nccwpck_require__(2692)
 var TypeOverrides = __nccwpck_require__(8873)
 
 var ConnectionParameters = __nccwpck_require__(9112)
 var Query = __nccwpck_require__(1283)
 var defaults = __nccwpck_require__(7886)
 var Connection = __nccwpck_require__(2848)
+const crypto = __nccwpck_require__(6947)
 
 class Client extends EventEmitter {
   constructor(config) {
@@ -1800,6 +1820,7 @@ class Client extends EventEmitter {
     this._Promise = c.Promise || global.Promise
     this._types = new TypeOverrides(c.types)
     this._ending = false
+    this._ended = false
     this._connecting = false
     this._connected = false
     this._connectionError = false
@@ -1895,6 +1916,7 @@ class Client extends EventEmitter {
 
       clearTimeout(this.connectionTimeoutHandle)
       this._errorAllQueries(error)
+      this._ended = true
 
       if (!this._ending) {
         // if the connection is ended without us calling .end()
@@ -1986,12 +2008,17 @@ class Client extends EventEmitter {
     } else if (this.password !== null) {
       cb()
     } else {
-      pgPass(this.connectionParameters, (pass) => {
-        if (undefined !== pass) {
-          this.connectionParameters.password = this.password = pass
-        }
-        cb()
-      })
+      try {
+        const pgPass = __nccwpck_require__(9713)
+        pgPass(this.connectionParameters, (pass) => {
+          if (undefined !== pass) {
+            this.connectionParameters.password = this.password = pass
+          }
+          cb()
+        })
+      } catch (e) {
+        this.emit('error', e)
+      }
     }
   }
 
@@ -2002,27 +2029,43 @@ class Client extends EventEmitter {
   }
 
   _handleAuthMD5Password(msg) {
-    this._checkPgPass(() => {
-      const hashedPassword = utils.postgresMd5PasswordHash(this.user, this.password, msg.salt)
-      this.connection.password(hashedPassword)
+    this._checkPgPass(async () => {
+      try {
+        const hashedPassword = await crypto.postgresMd5PasswordHash(this.user, this.password, msg.salt)
+        this.connection.password(hashedPassword)
+      } catch (e) {
+        this.emit('error', e)
+      }
     })
   }
 
   _handleAuthSASL(msg) {
     this._checkPgPass(() => {
-      this.saslSession = sasl.startSession(msg.mechanisms)
-      this.connection.sendSASLInitialResponseMessage(this.saslSession.mechanism, this.saslSession.response)
+      try {
+        this.saslSession = sasl.startSession(msg.mechanisms)
+        this.connection.sendSASLInitialResponseMessage(this.saslSession.mechanism, this.saslSession.response)
+      } catch (err) {
+        this.connection.emit('error', err)
+      }
     })
   }
 
-  _handleAuthSASLContinue(msg) {
-    sasl.continueSession(this.saslSession, this.password, msg.data)
-    this.connection.sendSCRAMClientFinalMessage(this.saslSession.response)
+  async _handleAuthSASLContinue(msg) {
+    try {
+      await sasl.continueSession(this.saslSession, this.password, msg.data)
+      this.connection.sendSCRAMClientFinalMessage(this.saslSession.response)
+    } catch (err) {
+      this.connection.emit('error', err)
+    }
   }
 
   _handleAuthSASLFinal(msg) {
-    sasl.finalizeSession(this.saslSession, msg.data)
-    this.saslSession = null
+    try {
+      sasl.finalizeSession(this.saslSession, msg.data)
+      this.saslSession = null
+    } catch (err) {
+      this.connection.emit('error', err)
+    }
   }
 
   _handleBackendKeyData(msg) {
@@ -2165,6 +2208,9 @@ class Client extends EventEmitter {
     if (params.statement_timeout) {
       data.statement_timeout = String(parseInt(params.statement_timeout, 10))
     }
+    if (params.lock_timeout) {
+      data.lock_timeout = String(parseInt(params.lock_timeout, 10))
+    }
     if (params.idle_in_transaction_session_timeout) {
       data.idle_in_transaction_session_timeout = String(parseInt(params.idle_in_transaction_session_timeout, 10))
     }
@@ -2202,35 +2248,15 @@ class Client extends EventEmitter {
     return this._types.getTypeParser(oid, format)
   }
 
-  // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
+  // escapeIdentifier and escapeLiteral moved to utility functions & exported
+  // on PG
+  // re-exported here for backwards compatibility
   escapeIdentifier(str) {
-    return '"' + str.replace(/"/g, '""') + '"'
+    return utils.escapeIdentifier(str)
   }
 
-  // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
   escapeLiteral(str) {
-    var hasBackslash = false
-    var escaped = "'"
-
-    for (var i = 0; i < str.length; i++) {
-      var c = str[i]
-      if (c === "'") {
-        escaped += c + c
-      } else if (c === '\\') {
-        escaped += c + c
-        hasBackslash = true
-      } else {
-        escaped += c
-      }
-    }
-
-    escaped += "'"
-
-    if (hasBackslash === true) {
-      escaped = ' E' + escaped
-    }
-
-    return escaped
+    return utils.escapeLiteral(str)
   }
 
   _pulseQueryQueue() {
@@ -2277,6 +2303,11 @@ class Client extends EventEmitter {
       if (!query.callback) {
         result = new this._Promise((resolve, reject) => {
           query.callback = (err, res) => (err ? reject(err) : resolve(res))
+        }).catch(err => {
+          // replace the stack trace that leads to `TCP.onStreamRead` with one that leads back to the
+          // application that created the query
+          Error.captureStackTrace(err);
+          throw err;
         })
       }
     }
@@ -2339,11 +2370,19 @@ class Client extends EventEmitter {
     return result
   }
 
+  ref() {
+    this.connection.ref()
+  }
+
+  unref() {
+    this.connection.unref()
+  }
+
   end(cb) {
     this._ending = true
 
     // if we have never connected, then end is a noop, callback immediately
-    if (!this.connection._connecting) {
+    if (!this.connection._connecting || this._ended) {
       if (cb) {
         cb()
       } else {
@@ -2383,11 +2422,11 @@ module.exports = Client
 "use strict";
 
 
-var dns = __nccwpck_require__(881)
+var dns = __nccwpck_require__(9523)
 
 var defaults = __nccwpck_require__(7886)
 
-var parse = __nccwpck_require__(8961).parse // parses a connection string
+var parse = (__nccwpck_require__(8961).parse) // parses a connection string
 
 var val = function (key, config, envVar) {
   if (envVar === undefined) {
@@ -2486,6 +2525,7 @@ class ConnectionParameters {
     this.application_name = val('application_name', config, 'PGAPPNAME')
     this.fallback_application_name = val('fallback_application_name', config, false)
     this.statement_timeout = val('statement_timeout', config, false)
+    this.lock_timeout = val('lock_timeout', config, false)
     this.idle_in_transaction_session_timeout = val('idle_in_transaction_session_timeout', config, false)
     this.query_timeout = val('query_timeout', config, false)
 
@@ -2557,10 +2597,11 @@ module.exports = ConnectionParameters
 "use strict";
 
 
-var net = __nccwpck_require__(1631)
-var EventEmitter = __nccwpck_require__(8614).EventEmitter
+var net = __nccwpck_require__(1808)
+var EventEmitter = (__nccwpck_require__(2361).EventEmitter)
 
 const { parse, serialize } = __nccwpck_require__(1113)
+const { getStream, getSecureStream } = __nccwpck_require__(3389)
 
 const flushBuffer = serialize.flush()
 const syncBuffer = serialize.sync()
@@ -2571,7 +2612,12 @@ class Connection extends EventEmitter {
   constructor(config) {
     super()
     config = config || {}
-    this.stream = config.stream || new net.Socket()
+
+    this.stream = config.stream || getStream(config.ssl)
+    if (typeof this.stream === 'function') {
+      this.stream = this.stream(config)
+    }
+
     this._keepAlive = config.keepAlive
     this._keepAliveInitialDelayMillis = config.keepAliveInitialDelayMillis
     this.lastBuffer = false
@@ -2631,7 +2677,6 @@ class Connection extends EventEmitter {
           self.stream.end()
           return self.emit('error', new Error('There was an error establishing an SSL connection'))
       }
-      var tls = __nccwpck_require__(4016)
       const options = {
         socket: self.stream,
       }
@@ -2644,11 +2689,12 @@ class Connection extends EventEmitter {
         }
       }
 
-      if (net.isIP(host) === 0) {
+      var net = __nccwpck_require__(1808)
+      if (net.isIP && net.isIP(host) === 0) {
         options.servername = host
       }
       try {
-        self.stream = tls.connect(options)
+        self.stream = getSecureStream(options)
       } catch (err) {
         return self.emit('error', err)
       }
@@ -2660,9 +2706,6 @@ class Connection extends EventEmitter {
   }
 
   attachListeners(stream) {
-    stream.on('end', () => {
-      this.emit('end')
-    })
     parse(stream, (msg) => {
       var eventName = msg.name === 'error' ? 'errorMessage' : msg.name
       if (this._emitMessage) {
@@ -2730,8 +2773,15 @@ class Connection extends EventEmitter {
 
   sync() {
     this._ending = true
-    this._send(flushBuffer)
     this._send(syncBuffer)
+  }
+
+  ref() {
+    this.stream.ref()
+  }
+
+  unref() {
+    this.stream.unref()
   }
 
   end() {
@@ -2768,6 +2818,352 @@ class Connection extends EventEmitter {
 }
 
 module.exports = Connection
+
+
+/***/ }),
+
+/***/ 2692:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+const crypto = __nccwpck_require__(6947)
+
+function startSession(mechanisms) {
+  if (mechanisms.indexOf('SCRAM-SHA-256') === -1) {
+    throw new Error('SASL: Only mechanism SCRAM-SHA-256 is currently supported')
+  }
+
+  const clientNonce = crypto.randomBytes(18).toString('base64')
+
+  return {
+    mechanism: 'SCRAM-SHA-256',
+    clientNonce,
+    response: 'n,,n=*,r=' + clientNonce,
+    message: 'SASLInitialResponse',
+  }
+}
+
+async function continueSession(session, password, serverData) {
+  if (session.message !== 'SASLInitialResponse') {
+    throw new Error('SASL: Last message was not SASLInitialResponse')
+  }
+  if (typeof password !== 'string') {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string')
+  }
+  if (password === '') {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a non-empty string')
+  }
+  if (typeof serverData !== 'string') {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: serverData must be a string')
+  }
+
+  const sv = parseServerFirstMessage(serverData)
+
+  if (!sv.nonce.startsWith(session.clientNonce)) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce does not start with client nonce')
+  } else if (sv.nonce.length === session.clientNonce.length) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce is too short')
+  }
+
+  var clientFirstMessageBare = 'n=*,r=' + session.clientNonce
+  var serverFirstMessage = 'r=' + sv.nonce + ',s=' + sv.salt + ',i=' + sv.iteration
+  var clientFinalMessageWithoutProof = 'c=biws,r=' + sv.nonce
+  var authMessage = clientFirstMessageBare + ',' + serverFirstMessage + ',' + clientFinalMessageWithoutProof
+
+  var saltBytes = Buffer.from(sv.salt, 'base64')
+  var saltedPassword = await crypto.deriveKey(password, saltBytes, sv.iteration)
+  var clientKey = await crypto.hmacSha256(saltedPassword, 'Client Key')
+  var storedKey = await crypto.sha256(clientKey)
+  var clientSignature = await crypto.hmacSha256(storedKey, authMessage)
+  var clientProof = xorBuffers(Buffer.from(clientKey), Buffer.from(clientSignature)).toString('base64')
+  var serverKey = await crypto.hmacSha256(saltedPassword, 'Server Key')
+  var serverSignatureBytes = await crypto.hmacSha256(serverKey, authMessage)
+
+  session.message = 'SASLResponse'
+  session.serverSignature = Buffer.from(serverSignatureBytes).toString('base64')
+  session.response = clientFinalMessageWithoutProof + ',p=' + clientProof
+}
+
+function finalizeSession(session, serverData) {
+  if (session.message !== 'SASLResponse') {
+    throw new Error('SASL: Last message was not SASLResponse')
+  }
+  if (typeof serverData !== 'string') {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: serverData must be a string')
+  }
+
+  const { serverSignature } = parseServerFinalMessage(serverData)
+
+  if (serverSignature !== session.serverSignature) {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature does not match')
+  }
+}
+
+/**
+ * printable       = %x21-2B / %x2D-7E
+ *                   ;; Printable ASCII except ",".
+ *                   ;; Note that any "printable" is also
+ *                   ;; a valid "value".
+ */
+function isPrintableChars(text) {
+  if (typeof text !== 'string') {
+    throw new TypeError('SASL: text must be a string')
+  }
+  return text
+    .split('')
+    .map((_, i) => text.charCodeAt(i))
+    .every((c) => (c >= 0x21 && c <= 0x2b) || (c >= 0x2d && c <= 0x7e))
+}
+
+/**
+ * base64-char     = ALPHA / DIGIT / "/" / "+"
+ *
+ * base64-4        = 4base64-char
+ *
+ * base64-3        = 3base64-char "="
+ *
+ * base64-2        = 2base64-char "=="
+ *
+ * base64          = *base64-4 [base64-3 / base64-2]
+ */
+function isBase64(text) {
+  return /^(?:[a-zA-Z0-9+/]{4})*(?:[a-zA-Z0-9+/]{2}==|[a-zA-Z0-9+/]{3}=)?$/.test(text)
+}
+
+function parseAttributePairs(text) {
+  if (typeof text !== 'string') {
+    throw new TypeError('SASL: attribute pairs text must be a string')
+  }
+
+  return new Map(
+    text.split(',').map((attrValue) => {
+      if (!/^.=/.test(attrValue)) {
+        throw new Error('SASL: Invalid attribute pair entry')
+      }
+      const name = attrValue[0]
+      const value = attrValue.substring(2)
+      return [name, value]
+    })
+  )
+}
+
+function parseServerFirstMessage(data) {
+  const attrPairs = parseAttributePairs(data)
+
+  const nonce = attrPairs.get('r')
+  if (!nonce) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: nonce missing')
+  } else if (!isPrintableChars(nonce)) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: nonce must only contain printable characters')
+  }
+  const salt = attrPairs.get('s')
+  if (!salt) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: salt missing')
+  } else if (!isBase64(salt)) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: salt must be base64')
+  }
+  const iterationText = attrPairs.get('i')
+  if (!iterationText) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: iteration missing')
+  } else if (!/^[1-9][0-9]*$/.test(iterationText)) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: invalid iteration count')
+  }
+  const iteration = parseInt(iterationText, 10)
+
+  return {
+    nonce,
+    salt,
+    iteration,
+  }
+}
+
+function parseServerFinalMessage(serverData) {
+  const attrPairs = parseAttributePairs(serverData)
+  const serverSignature = attrPairs.get('v')
+  if (!serverSignature) {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature is missing')
+  } else if (!isBase64(serverSignature)) {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature must be base64')
+  }
+  return {
+    serverSignature,
+  }
+}
+
+function xorBuffers(a, b) {
+  if (!Buffer.isBuffer(a)) {
+    throw new TypeError('first argument must be a Buffer')
+  }
+  if (!Buffer.isBuffer(b)) {
+    throw new TypeError('second argument must be a Buffer')
+  }
+  if (a.length !== b.length) {
+    throw new Error('Buffer lengths must match')
+  }
+  if (a.length === 0) {
+    throw new Error('Buffers cannot be empty')
+  }
+  return Buffer.from(a.map((_, i) => a[i] ^ b[i]))
+}
+
+module.exports = {
+  startSession,
+  continueSession,
+  finalizeSession,
+}
+
+
+/***/ }),
+
+/***/ 2272:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+// This file contains crypto utility functions for versions of Node.js < 15.0.0,
+// which does not support the WebCrypto.subtle API.
+
+const nodeCrypto = __nccwpck_require__(6113)
+
+function md5(string) {
+  return nodeCrypto.createHash('md5').update(string, 'utf-8').digest('hex')
+}
+
+// See AuthenticationMD5Password at https://www.postgresql.org/docs/current/static/protocol-flow.html
+function postgresMd5PasswordHash(user, password, salt) {
+  var inner = md5(password + user)
+  var outer = md5(Buffer.concat([Buffer.from(inner), salt]))
+  return 'md5' + outer
+}
+
+function sha256(text) {
+  return nodeCrypto.createHash('sha256').update(text).digest()
+}
+
+function hmacSha256(key, msg) {
+  return nodeCrypto.createHmac('sha256', key).update(msg).digest()
+}
+
+async function deriveKey(password, salt, iterations) {
+  return nodeCrypto.pbkdf2Sync(password, salt, iterations, 32, 'sha256')
+}
+
+module.exports = {
+  postgresMd5PasswordHash,
+  randomBytes: nodeCrypto.randomBytes,
+  deriveKey,
+  sha256,
+  hmacSha256,
+  md5,
+}
+
+
+/***/ }),
+
+/***/ 1288:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const nodeCrypto = __nccwpck_require__(6113)
+
+module.exports = {
+  postgresMd5PasswordHash,
+  randomBytes,
+  deriveKey,
+  sha256,
+  hmacSha256,
+  md5,
+}
+
+/**
+ * The Web Crypto API - grabbed from the Node.js library or the global
+ * @type Crypto
+ */
+const webCrypto = nodeCrypto.webcrypto || globalThis.crypto
+/**
+ * The SubtleCrypto API for low level crypto operations.
+ * @type SubtleCrypto
+ */
+const subtleCrypto = webCrypto.subtle
+const textEncoder = new TextEncoder()
+
+/**
+ *
+ * @param {*} length
+ * @returns
+ */
+function randomBytes(length) {
+  return webCrypto.getRandomValues(Buffer.alloc(length))
+}
+
+async function md5(string) {
+  try {
+    return nodeCrypto.createHash('md5').update(string, 'utf-8').digest('hex')
+  } catch (e) {
+    // `createHash()` failed so we are probably not in Node.js, use the WebCrypto API instead.
+    // Note that the MD5 algorithm on WebCrypto is not available in Node.js.
+    // This is why we cannot just use WebCrypto in all environments.
+    const data = typeof string === 'string' ? textEncoder.encode(string) : string
+    const hash = await subtleCrypto.digest('MD5', data)
+    return Array.from(new Uint8Array(hash))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('')
+  }
+}
+
+// See AuthenticationMD5Password at https://www.postgresql.org/docs/current/static/protocol-flow.html
+async function postgresMd5PasswordHash(user, password, salt) {
+  var inner = await md5(password + user)
+  var outer = await md5(Buffer.concat([Buffer.from(inner), salt]))
+  return 'md5' + outer
+}
+
+/**
+ * Create a SHA-256 digest of the given data
+ * @param {Buffer} data
+ */
+async function sha256(text) {
+  return await subtleCrypto.digest('SHA-256', text)
+}
+
+/**
+ * Sign the message with the given key
+ * @param {ArrayBuffer} keyBuffer
+ * @param {string} msg
+ */
+async function hmacSha256(keyBuffer, msg) {
+  const key = await subtleCrypto.importKey('raw', keyBuffer, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  return await subtleCrypto.sign('HMAC', key, textEncoder.encode(msg))
+}
+
+/**
+ * Derive a key from the password and salt
+ * @param {string} password
+ * @param {Uint8Array} salt
+ * @param {number} iterations
+ */
+async function deriveKey(password, salt, iterations) {
+  const key = await subtleCrypto.importKey('raw', textEncoder.encode(password), 'PBKDF2', false, ['deriveBits'])
+  const params = { name: 'PBKDF2', hash: 'SHA-256', salt: salt, iterations: iterations }
+  return await subtleCrypto.deriveBits(params, key, 32 * 8, ['deriveBits'])
+}
+
+
+/***/ }),
+
+/***/ 6947:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const useLegacyCrypto = parseInt(process.versions && process.versions.node && process.versions.node.split('.')[0]) < 15
+if (useLegacyCrypto) {
+  // We are on an old version of Node.js that requires legacy crypto utilities.
+  module.exports = __nccwpck_require__(2272)
+} else {
+  module.exports = __nccwpck_require__(1288);
+}
 
 
 /***/ }),
@@ -2832,6 +3228,10 @@ module.exports = {
   // false=unlimited
   statement_timeout: false,
 
+  // Abort any statement that waits longer than the specified duration in milliseconds while attempting to acquire a lock.
+  // false=unlimited
+  lock_timeout: false,
+
   // Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds
   // false=unlimited
   idle_in_transaction_session_timeout: false,
@@ -2866,7 +3266,7 @@ module.exports.__defineSetter__('parseInt8', function (val) {
 "use strict";
 
 
-const { EventEmitter } = __nccwpck_require__(8614)
+const { EventEmitter } = __nccwpck_require__(2361)
 
 const Result = __nccwpck_require__(6736)
 const utils = __nccwpck_require__(6419)
@@ -3001,7 +3401,14 @@ class Query extends EventEmitter {
       return this.handleError(this._canceledDueToError, con)
     }
     if (this.callback) {
-      this.callback(null, this._results)
+      try {
+        this.callback(null, this._results)
+      }
+      catch(err) {
+        process.nextTick(() => {
+          throw err
+        })
+      }
     }
     this.emit('end', this._results)
   }
@@ -3210,218 +3617,36 @@ module.exports = Result
 
 /***/ }),
 
-/***/ 9481:
+/***/ 3389:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-const crypto = __nccwpck_require__(6417)
-
-function startSession(mechanisms) {
-  if (mechanisms.indexOf('SCRAM-SHA-256') === -1) {
-    throw new Error('SASL: Only mechanism SCRAM-SHA-256 is currently supported')
-  }
-
-  const clientNonce = crypto.randomBytes(18).toString('base64')
-
-  return {
-    mechanism: 'SCRAM-SHA-256',
-    clientNonce,
-    response: 'n,,n=*,r=' + clientNonce,
-    message: 'SASLInitialResponse',
-  }
-}
-
-function continueSession(session, password, serverData) {
-  if (session.message !== 'SASLInitialResponse') {
-    throw new Error('SASL: Last message was not SASLInitialResponse')
-  }
-  if (typeof password !== 'string') {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string')
-  }
-  if (typeof serverData !== 'string') {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: serverData must be a string')
-  }
-
-  const sv = parseServerFirstMessage(serverData)
-
-  if (!sv.nonce.startsWith(session.clientNonce)) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce does not start with client nonce')
-  } else if (sv.nonce.length === session.clientNonce.length) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce is too short')
-  }
-
-  var saltBytes = Buffer.from(sv.salt, 'base64')
-
-  var saltedPassword = Hi(password, saltBytes, sv.iteration)
-
-  var clientKey = hmacSha256(saltedPassword, 'Client Key')
-  var storedKey = sha256(clientKey)
-
-  var clientFirstMessageBare = 'n=*,r=' + session.clientNonce
-  var serverFirstMessage = 'r=' + sv.nonce + ',s=' + sv.salt + ',i=' + sv.iteration
-
-  var clientFinalMessageWithoutProof = 'c=biws,r=' + sv.nonce
-
-  var authMessage = clientFirstMessageBare + ',' + serverFirstMessage + ',' + clientFinalMessageWithoutProof
-
-  var clientSignature = hmacSha256(storedKey, authMessage)
-  var clientProofBytes = xorBuffers(clientKey, clientSignature)
-  var clientProof = clientProofBytes.toString('base64')
-
-  var serverKey = hmacSha256(saltedPassword, 'Server Key')
-  var serverSignatureBytes = hmacSha256(serverKey, authMessage)
-
-  session.message = 'SASLResponse'
-  session.serverSignature = serverSignatureBytes.toString('base64')
-  session.response = clientFinalMessageWithoutProof + ',p=' + clientProof
-}
-
-function finalizeSession(session, serverData) {
-  if (session.message !== 'SASLResponse') {
-    throw new Error('SASL: Last message was not SASLResponse')
-  }
-  if (typeof serverData !== 'string') {
-    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: serverData must be a string')
-  }
-
-  const { serverSignature } = parseServerFinalMessage(serverData)
-
-  if (serverSignature !== session.serverSignature) {
-    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature does not match')
+/**
+ * Get a socket stream compatible with the current runtime environment.
+ * @returns {Duplex}
+ */
+module.exports.getStream = function getStream(ssl) {
+  const net = __nccwpck_require__(1808)
+  if (typeof net.Socket === 'function') {
+    return new net.Socket()
+  } else {
+    const { CloudflareSocket } = __nccwpck_require__(7078)
+    return new CloudflareSocket(ssl)
   }
 }
 
 /**
- * printable       = %x21-2B / %x2D-7E
- *                   ;; Printable ASCII except ",".
- *                   ;; Note that any "printable" is also
- *                   ;; a valid "value".
+ * Get a TLS secured socket, compatible with the current environment,
+ * using the socket and other settings given in `options`.
+ * @returns {Duplex}
  */
-function isPrintableChars(text) {
-  if (typeof text !== 'string') {
-    throw new TypeError('SASL: text must be a string')
+module.exports.getSecureStream = function getSecureStream(options) {
+  var tls = __nccwpck_require__(4404)
+  if (tls.connect) {
+    return tls.connect(options)
+  } else {
+    options.socket.startTls(options)
+    return options.socket
   }
-  return text
-    .split('')
-    .map((_, i) => text.charCodeAt(i))
-    .every((c) => (c >= 0x21 && c <= 0x2b) || (c >= 0x2d && c <= 0x7e))
-}
-
-/**
- * base64-char     = ALPHA / DIGIT / "/" / "+"
- *
- * base64-4        = 4base64-char
- *
- * base64-3        = 3base64-char "="
- *
- * base64-2        = 2base64-char "=="
- *
- * base64          = *base64-4 [base64-3 / base64-2]
- */
-function isBase64(text) {
-  return /^(?:[a-zA-Z0-9+/]{4})*(?:[a-zA-Z0-9+/]{2}==|[a-zA-Z0-9+/]{3}=)?$/.test(text)
-}
-
-function parseAttributePairs(text) {
-  if (typeof text !== 'string') {
-    throw new TypeError('SASL: attribute pairs text must be a string')
-  }
-
-  return new Map(
-    text.split(',').map((attrValue) => {
-      if (!/^.=/.test(attrValue)) {
-        throw new Error('SASL: Invalid attribute pair entry')
-      }
-      const name = attrValue[0]
-      const value = attrValue.substring(2)
-      return [name, value]
-    })
-  )
-}
-
-function parseServerFirstMessage(data) {
-  const attrPairs = parseAttributePairs(data)
-
-  const nonce = attrPairs.get('r')
-  if (!nonce) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: nonce missing')
-  } else if (!isPrintableChars(nonce)) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: nonce must only contain printable characters')
-  }
-  const salt = attrPairs.get('s')
-  if (!salt) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: salt missing')
-  } else if (!isBase64(salt)) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: salt must be base64')
-  }
-  const iterationText = attrPairs.get('i')
-  if (!iterationText) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: iteration missing')
-  } else if (!/^[1-9][0-9]*$/.test(iterationText)) {
-    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: invalid iteration count')
-  }
-  const iteration = parseInt(iterationText, 10)
-
-  return {
-    nonce,
-    salt,
-    iteration,
-  }
-}
-
-function parseServerFinalMessage(serverData) {
-  const attrPairs = parseAttributePairs(serverData)
-  const serverSignature = attrPairs.get('v')
-  if (!serverSignature) {
-    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature is missing')
-  } else if (!isBase64(serverSignature)) {
-    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature must be base64')
-  }
-  return {
-    serverSignature,
-  }
-}
-
-function xorBuffers(a, b) {
-  if (!Buffer.isBuffer(a)) {
-    throw new TypeError('first argument must be a Buffer')
-  }
-  if (!Buffer.isBuffer(b)) {
-    throw new TypeError('second argument must be a Buffer')
-  }
-  if (a.length !== b.length) {
-    throw new Error('Buffer lengths must match')
-  }
-  if (a.length === 0) {
-    throw new Error('Buffers cannot be empty')
-  }
-  return Buffer.from(a.map((_, i) => a[i] ^ b[i]))
-}
-
-function sha256(text) {
-  return crypto.createHash('sha256').update(text).digest()
-}
-
-function hmacSha256(key, msg) {
-  return crypto.createHmac('sha256', key).update(msg).digest()
-}
-
-function Hi(password, saltBytes, iterations) {
-  var ui1 = hmacSha256(password, Buffer.concat([saltBytes, Buffer.from([0, 0, 0, 1])]))
-  var ui = ui1
-  for (var i = 0; i < iterations - 1; i++) {
-    ui1 = hmacSha256(password, ui1)
-    ui = xorBuffers(ui, ui1)
-  }
-
-  return ui
-}
-
-module.exports = {
-  startSession,
-  continueSession,
-  finalizeSession,
 }
 
 
@@ -3475,8 +3700,6 @@ module.exports = TypeOverrides
 
 "use strict";
 
-
-const crypto = __nccwpck_require__(6417)
 
 const defaults = __nccwpck_require__(7886)
 
@@ -3640,15 +3863,34 @@ function normalizeQueryConfig(config, values, callback) {
   return config
 }
 
-const md5 = function (string) {
-  return crypto.createHash('md5').update(string, 'utf-8').digest('hex')
+// Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
+const escapeIdentifier = function (str) {
+  return '"' + str.replace(/"/g, '""') + '"'
 }
 
-// See AuthenticationMD5Password at https://www.postgresql.org/docs/current/static/protocol-flow.html
-const postgresMd5PasswordHash = function (user, password, salt) {
-  var inner = md5(password + user)
-  var outer = md5(Buffer.concat([Buffer.from(inner), salt]))
-  return 'md5' + outer
+const escapeLiteral = function (str) {
+  var hasBackslash = false
+  var escaped = "'"
+
+  for (var i = 0; i < str.length; i++) {
+    var c = str[i]
+    if (c === "'") {
+      escaped += c + c
+    } else if (c === '\\') {
+      escaped += c + c
+      hasBackslash = true
+    } else {
+      escaped += c
+    }
+  }
+
+  escaped += "'"
+
+  if (hasBackslash === true) {
+    escaped = ' E' + escaped
+  }
+
+  return escaped
 }
 
 module.exports = {
@@ -3658,8 +3900,8 @@ module.exports = {
     return prepareValue(value)
   },
   normalizeQueryConfig,
-  postgresMd5PasswordHash,
-  md5,
+  escapeIdentifier,
+  escapeLiteral,
 }
 
 
@@ -3671,10 +3913,10 @@ module.exports = {
 "use strict";
 
 
-var path = __nccwpck_require__(5622)
-  , Stream = __nccwpck_require__(2413).Stream
+var path = __nccwpck_require__(1017)
+  , Stream = (__nccwpck_require__(2781).Stream)
   , split = __nccwpck_require__(5000)
-  , util = __nccwpck_require__(1669)
+  , util = __nccwpck_require__(3837)
   , defaultPort = 5432
   , isWin = (process.platform === 'win32')
   , warnStream = process.stderr
@@ -3912,8 +4154,8 @@ var isValidEntry = module.exports.isValidEntry = function(entry){
 "use strict";
 
 
-var path = __nccwpck_require__(5622)
-  , fs = __nccwpck_require__(5747)
+var path = __nccwpck_require__(1017)
+  , fs = __nccwpck_require__(7147)
   , helper = __nccwpck_require__(6926)
 ;
 
@@ -4689,7 +4931,7 @@ var Duplex;
 Readable.ReadableState = ReadableState;
 /*<replacement>*/
 
-var EE = __nccwpck_require__(8614).EventEmitter;
+var EE = (__nccwpck_require__(2361).EventEmitter);
 
 var EElistenerCount = function EElistenerCount(emitter, type) {
   return emitter.listeners(type).length;
@@ -4703,7 +4945,7 @@ var Stream = __nccwpck_require__(2387);
 /*</replacement>*/
 
 
-var Buffer = __nccwpck_require__(4293).Buffer;
+var Buffer = (__nccwpck_require__(4300).Buffer);
 
 var OurUint8Array = global.Uint8Array || function () {};
 
@@ -4717,7 +4959,7 @@ function _isUint8Array(obj) {
 /*<replacement>*/
 
 
-var debugUtil = __nccwpck_require__(1669);
+var debugUtil = __nccwpck_require__(3837);
 
 var debug;
 
@@ -4736,7 +4978,7 @@ var destroyImpl = __nccwpck_require__(7049);
 var _require = __nccwpck_require__(9948),
     getHighWaterMark = _require.getHighWaterMark;
 
-var _require$codes = __nccwpck_require__(7214)/* .codes */ .q,
+var _require$codes = (__nccwpck_require__(7214)/* .codes */ .q),
     ERR_INVALID_ARG_TYPE = _require$codes.ERR_INVALID_ARG_TYPE,
     ERR_STREAM_PUSH_AFTER_EOF = _require$codes.ERR_STREAM_PUSH_AFTER_EOF,
     ERR_METHOD_NOT_IMPLEMENTED = _require$codes.ERR_METHOD_NOT_IMPLEMENTED,
@@ -4820,7 +5062,7 @@ function ReadableState(options, stream, isDuplex) {
   this.encoding = null;
 
   if (options.encoding) {
-    if (!StringDecoder) StringDecoder = __nccwpck_require__(4841)/* .StringDecoder */ .s;
+    if (!StringDecoder) StringDecoder = (__nccwpck_require__(4841)/* .StringDecoder */ .s);
     this.decoder = new StringDecoder(options.encoding);
     this.encoding = options.encoding;
   }
@@ -4982,7 +5224,7 @@ Readable.prototype.isPaused = function () {
 
 
 Readable.prototype.setEncoding = function (enc) {
-  if (!StringDecoder) StringDecoder = __nccwpck_require__(4841)/* .StringDecoder */ .s;
+  if (!StringDecoder) StringDecoder = (__nccwpck_require__(4841)/* .StringDecoder */ .s);
   var decoder = new StringDecoder(enc);
   this._readableState.decoder = decoder; // If setEncoding(null), decoder.encoding equals utf8
 
@@ -5854,7 +6096,7 @@ function indexOf(xs, x) {
 
 module.exports = Transform;
 
-var _require$codes = __nccwpck_require__(7214)/* .codes */ .q,
+var _require$codes = (__nccwpck_require__(7214)/* .codes */ .q),
     ERR_METHOD_NOT_IMPLEMENTED = _require$codes.ERR_METHOD_NOT_IMPLEMENTED,
     ERR_MULTIPLE_CALLBACK = _require$codes.ERR_MULTIPLE_CALLBACK,
     ERR_TRANSFORM_ALREADY_TRANSFORMING = _require$codes.ERR_TRANSFORM_ALREADY_TRANSFORMING,
@@ -6066,7 +6308,7 @@ var Stream = __nccwpck_require__(2387);
 /*</replacement>*/
 
 
-var Buffer = __nccwpck_require__(4293).Buffer;
+var Buffer = (__nccwpck_require__(4300).Buffer);
 
 var OurUint8Array = global.Uint8Array || function () {};
 
@@ -6083,7 +6325,7 @@ var destroyImpl = __nccwpck_require__(7049);
 var _require = __nccwpck_require__(9948),
     getHighWaterMark = _require.getHighWaterMark;
 
-var _require$codes = __nccwpck_require__(7214)/* .codes */ .q,
+var _require$codes = (__nccwpck_require__(7214)/* .codes */ .q),
     ERR_INVALID_ARG_TYPE = _require$codes.ERR_INVALID_ARG_TYPE,
     ERR_METHOD_NOT_IMPLEMENTED = _require$codes.ERR_METHOD_NOT_IMPLEMENTED,
     ERR_MULTIPLE_CALLBACK = _require$codes.ERR_MULTIPLE_CALLBACK,
@@ -6929,10 +7171,10 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-var _require = __nccwpck_require__(4293),
+var _require = __nccwpck_require__(4300),
     Buffer = _require.Buffer;
 
-var _require2 = __nccwpck_require__(1669),
+var _require2 = __nccwpck_require__(3837),
     inspect = _require2.inspect;
 
 var custom = inspect && inspect.custom || 'inspect';
@@ -7248,7 +7490,7 @@ module.exports = {
 // permission from the author, Mathias Buus (@mafintosh).
 
 
-var ERR_STREAM_PREMATURE_CLOSE = __nccwpck_require__(7214)/* .codes.ERR_STREAM_PREMATURE_CLOSE */ .q.ERR_STREAM_PREMATURE_CLOSE;
+var ERR_STREAM_PREMATURE_CLOSE = (__nccwpck_require__(7214)/* .codes.ERR_STREAM_PREMATURE_CLOSE */ .q.ERR_STREAM_PREMATURE_CLOSE);
 
 function once(callback) {
   var called = false;
@@ -7367,7 +7609,7 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var ERR_INVALID_ARG_TYPE = __nccwpck_require__(7214)/* .codes.ERR_INVALID_ARG_TYPE */ .q.ERR_INVALID_ARG_TYPE;
+var ERR_INVALID_ARG_TYPE = (__nccwpck_require__(7214)/* .codes.ERR_INVALID_ARG_TYPE */ .q.ERR_INVALID_ARG_TYPE);
 
 function from(Readable, iterable, opts) {
   var iterator;
@@ -7441,7 +7683,7 @@ function once(callback) {
   };
 }
 
-var _require$codes = __nccwpck_require__(7214)/* .codes */ .q,
+var _require$codes = (__nccwpck_require__(7214)/* .codes */ .q),
     ERR_MISSING_ARGS = _require$codes.ERR_MISSING_ARGS,
     ERR_STREAM_DESTROYED = _require$codes.ERR_STREAM_DESTROYED;
 
@@ -7532,7 +7774,7 @@ module.exports = pipeline;
 "use strict";
 
 
-var ERR_INVALID_OPT_VALUE = __nccwpck_require__(7214)/* .codes.ERR_INVALID_OPT_VALUE */ .q.ERR_INVALID_OPT_VALUE;
+var ERR_INVALID_OPT_VALUE = (__nccwpck_require__(7214)/* .codes.ERR_INVALID_OPT_VALUE */ .q.ERR_INVALID_OPT_VALUE);
 
 function highWaterMarkFrom(options, isDuplex, duplexKey) {
   return options.highWaterMark != null ? options.highWaterMark : isDuplex ? options[duplexKey] : null;
@@ -7563,7 +7805,7 @@ module.exports = {
 /***/ 2387:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(2413);
+module.exports = __nccwpck_require__(2781);
 
 
 /***/ }),
@@ -7571,7 +7813,7 @@ module.exports = __nccwpck_require__(2413);
 /***/ 1642:
 /***/ ((module, exports, __nccwpck_require__) => {
 
-var Stream = __nccwpck_require__(2413);
+var Stream = __nccwpck_require__(2781);
 if (process.env.READABLE_STREAM === 'disable' && Stream) {
   module.exports = Stream.Readable;
   Object.assign(module.exports, Stream);
@@ -7596,7 +7838,7 @@ if (process.env.READABLE_STREAM === 'disable' && Stream) {
 
 /*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
 /* eslint-disable node/no-deprecated-api */
-var buffer = __nccwpck_require__(4293)
+var buffer = __nccwpck_require__(4300)
 var Buffer = buffer.Buffer
 
 // alternative to using Object.keys for old browsers
@@ -7686,7 +7928,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 const { Transform } = __nccwpck_require__(1642)
-const { StringDecoder } = __nccwpck_require__(4304)
+const { StringDecoder } = __nccwpck_require__(1576)
 const kLast = Symbol('last')
 const kDecoder = Symbol('decoder')
 
@@ -7832,7 +8074,7 @@ module.exports = split
 
 /*<replacement>*/
 
-var Buffer = __nccwpck_require__(1867).Buffer;
+var Buffer = (__nccwpck_require__(1867).Buffer);
 /*</replacement>*/
 
 var isEncoding = Buffer.isEncoding || function (encoding) {
@@ -8114,7 +8356,7 @@ function simpleEnd(buf) {
  * For Node.js, simply re-export the core `util.deprecate` function.
  */
 
-module.exports = __nccwpck_require__(1669).deprecate;
+module.exports = __nccwpck_require__(3837).deprecate;
 
 
 /***/ }),
@@ -8143,107 +8385,99 @@ function extend(target) {
 
 /***/ }),
 
-/***/ 2357:
+/***/ 9491:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("assert");;
+module.exports = require("assert");
 
 /***/ }),
 
-/***/ 4293:
+/***/ 4300:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("buffer");;
+module.exports = require("buffer");
 
 /***/ }),
 
-/***/ 6417:
+/***/ 6113:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("crypto");;
+module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 881:
+/***/ 9523:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("dns");;
+module.exports = require("dns");
 
 /***/ }),
 
-/***/ 8614:
+/***/ 2361:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("events");;
+module.exports = require("events");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("fs");;
+module.exports = require("fs");
 
 /***/ }),
 
-/***/ 1631:
+/***/ 1808:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("net");;
+module.exports = require("net");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("path");;
+module.exports = require("path");
 
 /***/ }),
 
-/***/ 2413:
+/***/ 2781:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("stream");;
+module.exports = require("stream");
 
 /***/ }),
 
-/***/ 4304:
+/***/ 1576:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("string_decoder");;
+module.exports = require("string_decoder");
 
 /***/ }),
 
-/***/ 4016:
+/***/ 4404:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("tls");;
+module.exports = require("tls");
 
 /***/ }),
 
-/***/ 8835:
+/***/ 3837:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("url");;
-
-/***/ }),
-
-/***/ 1669:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("util");;
+module.exports = require("util");
 
 /***/ })
 
@@ -8322,7 +8556,9 @@ module.exports = require("util");;
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
 (() => {
@@ -8341,21 +8577,27 @@ var client_default = /*#__PURE__*/__nccwpck_require__.n(lib_client);
 // EXTERNAL MODULE: ./node_modules/pg-connection-string/index.js
 var pg_connection_string = __nccwpck_require__(8961);
 var pg_connection_string_default = /*#__PURE__*/__nccwpck_require__.n(pg_connection_string);
-;// CONCATENATED MODULE: external "aws-sdk/clients/ssm"
-const ssm_namespaceObject = require("aws-sdk/clients/ssm");;
-var ssm_default = /*#__PURE__*/__nccwpck_require__.n(ssm_namespaceObject);
+;// CONCATENATED MODULE: external "@aws-sdk/client-ssm"
+const client_ssm_namespaceObject = require("@aws-sdk/client-ssm");
 ;// CONCATENATED MODULE: ./index.ts
 
 
 
-const ssmClient = new (ssm_default())({});
+const ssmClient = new client_ssm_namespaceObject.SSMClient({});
 async function handler({ database, queries }) {
     const clientConfig = pg_connection_string_default().parse(await getDatabaseUrl());
     if (database) {
         clientConfig.database = database;
     }
     console.log(`Connecting to the '${clientConfig.database}' database...`);
-    const client = new (client_default())(clientConfig);
+    const client = new (client_default())({
+        ...clientConfig,
+        // fix incompatibilities between pg and pg-connection-string
+        database: clientConfig.database ?? undefined,
+        host: clientConfig.host ?? undefined,
+        port: clientConfig.port ? Number(clientConfig.port) : undefined,
+        ssl: Boolean(clientConfig.ssl),
+    });
     await client.connect();
     try {
         for (const query of queries) {
@@ -8369,19 +8611,16 @@ async function handler({ database, queries }) {
     }
 }
 async function getDatabaseUrl() {
-    var _a;
     if (process.env.DATABASE_URL) {
         return process.env.DATABASE_URL;
     }
     if (process.env.DATABASE_URL_PARAM) {
         const paramName = process.env.DATABASE_URL_PARAM;
-        const result = await ssmClient
-            .getParameter({
+        const result = await ssmClient.send(new client_ssm_namespaceObject.GetParameterCommand({
             Name: paramName,
             WithDecryption: true,
-        })
-            .promise();
-        const paramValue = (_a = result.Parameter) === null || _a === void 0 ? void 0 : _a.Value;
+        }));
+        const paramValue = result.Parameter?.Value;
         if (!paramValue) {
             throw new Error(`Failed to fetch ${paramName} from SSM`);
         }

--- a/rds/postgres/management_lambda/dist/index.js.license
+++ b/rds/postgres/management_lambda/dist/index.js.license
@@ -1,13 +1,3 @@
-@vercel/ncc
-MIT
-Copyright 2018 ZEIT, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 inherits
 ISC
 The ISC License
@@ -29,6 +19,31 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 pg
+MIT
+MIT License
+
+Copyright (c) 2010 - 2021 Brian Carlson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+pg-cloudflare
 MIT
 MIT License
 

--- a/rds/postgres/management_lambda/main.tf
+++ b/rds/postgres/management_lambda/main.tf
@@ -37,6 +37,7 @@ module "lambda" {
 
   package_path = module.package.output_path
   handler      = "index.handler"
+  runtime      = "nodejs18.x"
 
   security_group_ids = var.create && var.vpc ? aws_security_group.lambda.*.id : null
   subnet_ids         = var.vpc ? var.subnet_ids : null

--- a/rds/postgres/management_lambda/src/index.ts
+++ b/rds/postgres/management_lambda/src/index.ts
@@ -1,8 +1,7 @@
-import { ClientConfig } from "pg"
 import Client from "pg/lib/client"
 import pgConnectionString from "pg-connection-string"
 
-import SSMClient from "aws-sdk/clients/ssm"
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm"
 
 interface Event {
   queries: string[]
@@ -12,16 +11,22 @@ interface Event {
 const ssmClient = new SSMClient({})
 
 export async function handler({ database, queries }: Event) {
-  const clientConfig = pgConnectionString.parse(
-    await getDatabaseUrl(),
-  ) as ClientConfig
+  const clientConfig = pgConnectionString.parse(await getDatabaseUrl())
 
   if (database) {
     clientConfig.database = database
   }
 
   console.log(`Connecting to the '${clientConfig.database}' database...`)
-  const client = new Client(clientConfig)
+  const client = new Client({
+    ...clientConfig,
+
+    // fix incompatibilities between pg and pg-connection-string
+    database: clientConfig.database ?? undefined,
+    host: clientConfig.host ?? undefined,
+    port: clientConfig.port ? Number(clientConfig.port) : undefined,
+    ssl: Boolean(clientConfig.ssl),
+  })
   await client.connect()
 
   try {
@@ -43,12 +48,12 @@ async function getDatabaseUrl() {
   if (process.env.DATABASE_URL_PARAM) {
     const paramName = process.env.DATABASE_URL_PARAM
 
-    const result = await ssmClient
-      .getParameter({
+    const result = await ssmClient.send(
+      new GetParameterCommand({
         Name: paramName,
         WithDecryption: true,
       })
-      .promise()
+    )
 
     const paramValue = result.Parameter?.Value
 

--- a/rds/postgres/management_lambda/src/package-lock.json
+++ b/rds/postgres/management_lambda/src/package-lock.json
@@ -1,269 +1,1238 @@
 {
   "name": "rds-postgres-management-lambda",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "@tsconfig/node12": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.7.tgz",
-      "integrity": "sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "12.20.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
-      "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A=="
-    },
-    "@types/pg": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.0.tgz",
-      "integrity": "sha512-3JXFrsl8COoqVB1+2Pqelx6soaiFVXzkT3fkuSNe7GB40ysfT0FHphZFPiqIXpMyTHSFRdLTyZzrFBrJRPAArA==",
-      "requires": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^2.2.0"
+  "packages": {
+    "": {
+      "name": "rds-postgres-management-lambda",
+      "dependencies": {
+        "@aws-sdk/client-ssm": "3.188.0",
+        "@types/node": "^18.17.1",
+        "@types/pg": "^8.10.2",
+        "pg": "^8.11.2",
+        "pg-connection-string": "^2.6.2"
+      },
+      "devDependencies": {
+        "@tsconfig/node18": "^18.2.0",
+        "@vercel/ncc": "^0.36.1",
+        "typescript": "^5.1.6"
       }
     },
-    "@vercel/ncc": {
-      "version": "0.28.6",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.28.6.tgz",
-      "integrity": "sha512-t4BoSSuyK8BZaUE0gV18V6bkFs4st7baumtFGa50dv1tMu2GDBEBF8sUZaKBdKiL6DzJ2D2+XVCwYWWDcQOYdQ==",
-      "dev": true
-    },
-    "aws-sdk": {
-      "version": "2.918.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.918.0.tgz",
-      "integrity": "sha512-ZjWanOA1Zo664EyWLCnbUlkwCjoRPmSIMx529W4gk1418qo3oCEcvUy1HeibGGIClYnZZ7J4FMQvVDm2+JtHLQ==",
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
-      },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
       "dependencies": {
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.188.0.tgz",
+      "integrity": "sha512-H6R99n5t6Ov/y1CSLnvab8g//0KmE/G4Qoh7634FGW0vZazx16YJcUkwKgb+U+Gsiv85zTus9sv0DzjEImztAw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.188.0.tgz",
+      "integrity": "sha512-NkhrWnFak0T2B1Yh9IzN1qNJdcyzaRxxS5D+Wsc/ORiwGvknxR6jtKhk9ZvXEQZFjs0wfYSW7kSewG94ikkKZA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.188.0",
+        "@aws-sdk/config-resolver": "3.188.0",
+        "@aws-sdk/credential-provider-node": "3.188.0",
+        "@aws-sdk/fetch-http-handler": "3.188.0",
+        "@aws-sdk/hash-node": "3.188.0",
+        "@aws-sdk/invalid-dependency": "3.188.0",
+        "@aws-sdk/middleware-content-length": "3.188.0",
+        "@aws-sdk/middleware-host-header": "3.188.0",
+        "@aws-sdk/middleware-logger": "3.188.0",
+        "@aws-sdk/middleware-recursion-detection": "3.188.0",
+        "@aws-sdk/middleware-retry": "3.188.0",
+        "@aws-sdk/middleware-serde": "3.188.0",
+        "@aws-sdk/middleware-signing": "3.188.0",
+        "@aws-sdk/middleware-stack": "3.188.0",
+        "@aws-sdk/middleware-user-agent": "3.188.0",
+        "@aws-sdk/node-config-provider": "3.188.0",
+        "@aws-sdk/node-http-handler": "3.188.0",
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/smithy-client": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/url-parser": "3.188.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.188.0",
+        "@aws-sdk/util-defaults-mode-node": "3.188.0",
+        "@aws-sdk/util-user-agent-browser": "3.188.0",
+        "@aws-sdk/util-user-agent-node": "3.188.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-waiter": "3.188.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.188.0.tgz",
+      "integrity": "sha512-6josKD8aC6tAazXSpr3EJ9OhuD8l5RYSc+WmziD4fWh+TUha/ATHBBELSruKriyN9OQgFzXGg1mJkqTUpImyuw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.188.0",
+        "@aws-sdk/fetch-http-handler": "3.188.0",
+        "@aws-sdk/hash-node": "3.188.0",
+        "@aws-sdk/invalid-dependency": "3.188.0",
+        "@aws-sdk/middleware-content-length": "3.188.0",
+        "@aws-sdk/middleware-host-header": "3.188.0",
+        "@aws-sdk/middleware-logger": "3.188.0",
+        "@aws-sdk/middleware-recursion-detection": "3.188.0",
+        "@aws-sdk/middleware-retry": "3.188.0",
+        "@aws-sdk/middleware-serde": "3.188.0",
+        "@aws-sdk/middleware-stack": "3.188.0",
+        "@aws-sdk/middleware-user-agent": "3.188.0",
+        "@aws-sdk/node-config-provider": "3.188.0",
+        "@aws-sdk/node-http-handler": "3.188.0",
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/smithy-client": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/url-parser": "3.188.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.188.0",
+        "@aws-sdk/util-defaults-mode-node": "3.188.0",
+        "@aws-sdk/util-user-agent-browser": "3.188.0",
+        "@aws-sdk/util-user-agent-node": "3.188.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.188.0.tgz",
+      "integrity": "sha512-Zpy7iCLPLLP0ZykzRp/VK952xoKPv2NaZnqD0/h1zNp7H+ncaC/1IeWufTp/MQBRnlF2gZfof20GT2K2BGhQoA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.188.0",
+        "@aws-sdk/credential-provider-node": "3.188.0",
+        "@aws-sdk/fetch-http-handler": "3.188.0",
+        "@aws-sdk/hash-node": "3.188.0",
+        "@aws-sdk/invalid-dependency": "3.188.0",
+        "@aws-sdk/middleware-content-length": "3.188.0",
+        "@aws-sdk/middleware-host-header": "3.188.0",
+        "@aws-sdk/middleware-logger": "3.188.0",
+        "@aws-sdk/middleware-recursion-detection": "3.188.0",
+        "@aws-sdk/middleware-retry": "3.188.0",
+        "@aws-sdk/middleware-sdk-sts": "3.188.0",
+        "@aws-sdk/middleware-serde": "3.188.0",
+        "@aws-sdk/middleware-signing": "3.188.0",
+        "@aws-sdk/middleware-stack": "3.188.0",
+        "@aws-sdk/middleware-user-agent": "3.188.0",
+        "@aws-sdk/node-config-provider": "3.188.0",
+        "@aws-sdk/node-http-handler": "3.188.0",
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/smithy-client": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/url-parser": "3.188.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.188.0",
+        "@aws-sdk/util-defaults-mode-node": "3.188.0",
+        "@aws-sdk/util-user-agent-browser": "3.188.0",
+        "@aws-sdk/util-user-agent-node": "3.188.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.188.0.tgz",
+      "integrity": "sha512-p+izFghzVWKYy8bqZI65l5hok8Gi8zLM2aHtZoaK3meQJmoK7MNrICzZOaUZ+DcGH6zMItf3XFGhL0iw9PJHow==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
+        "@aws-sdk/util-middleware": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.188.0.tgz",
+      "integrity": "sha512-QOyUQ6B3EnO27HLqSvIewiMgytJmmIbEe1oj90j9oydjur9kdkf3WTrO4vJZD4U+3RJMDalXrJq/ZQQuSYN4Aw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.188.0.tgz",
+      "integrity": "sha512-0JmQdIAtzx5GuR1tLh6Ii76wzRD7YjRhyfv15spGFzdvTngADbifvC5dl7wdfkzssefabOPSf9XPlhjpf07Nvg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.188.0",
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/url-parser": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.188.0.tgz",
+      "integrity": "sha512-UYlUI6IxrNFqLaK5x3INM1/cn+U4SUDosT15l/5kcdGuZAIm3h6UpTOpt5t9gLQElaABOY+XXO0j0nPd+AB4Qw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.188.0",
+        "@aws-sdk/credential-provider-imds": "3.188.0",
+        "@aws-sdk/credential-provider-sso": "3.188.0",
+        "@aws-sdk/credential-provider-web-identity": "3.188.0",
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/shared-ini-file-loader": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.188.0.tgz",
+      "integrity": "sha512-5HKrMB7cPo4wvzyT6GlsQsvVjNH908+zROswj9j0mnUMBzyUIy8oWN8ZIwr4rDC/LW97TjImXDSexDHh/MVbvg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.188.0",
+        "@aws-sdk/credential-provider-imds": "3.188.0",
+        "@aws-sdk/credential-provider-ini": "3.188.0",
+        "@aws-sdk/credential-provider-process": "3.188.0",
+        "@aws-sdk/credential-provider-sso": "3.188.0",
+        "@aws-sdk/credential-provider-web-identity": "3.188.0",
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/shared-ini-file-loader": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.188.0.tgz",
+      "integrity": "sha512-OegpAw6G5YKQvYnxiUQclvuzRNWwBAp+y8T2HUV7ogwkPjGIClqPgTZYqiPahEduGpP7M5myGmw+ePrbqtQlCA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/shared-ini-file-loader": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.188.0.tgz",
+      "integrity": "sha512-VViA2nKX2Rg5qXmkdViAALvWirjKFFRJ2YyrTJ/SYMUkEPQL8wkc1VXuK6x4Y125Yj6zdB8jXJPr5R2uGG5ukQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.188.0",
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/shared-ini-file-loader": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.188.0.tgz",
+      "integrity": "sha512-J1izCsDW1IPSKRweWfs69NNTJBmygFfPiyKRdISiPDg4wIgt9rT1NrXNDo6x7JKCx5VeBMwN16fUXshIuPxIhA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.188.0.tgz",
+      "integrity": "sha512-+Mapt0fK766ngBPYKiD3Z74epWjrSUVgnyNeH+6Liyc/64D69gCaWCQ7fxNNnHs87Bq+rpuM008klAj4fK22pA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/querystring-builder": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.188.0.tgz",
+      "integrity": "sha512-alqui1u6bQRigD4AyaT0KQK/8F0Gp7+hLmW+Z9eVuhjo4Fq+Mz0lnS5tNULqRUEpr8Kxdo8qw0c9Wc4absUKHw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.188.0.tgz",
+      "integrity": "sha512-sc22A9z7GUSwF4ObQooMk9Y/Kw7w+0wPspy3VsF0cGtxz1EvA06hMIdhosTlKDje0ejrGmtFImeicU8QBBuezA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.188.0.tgz",
+      "integrity": "sha512-YAvAq8s7GdC24xLLl4t97Teen8BKtWG5W9ygny2gYF1omXz8wWezNEvnDR6ppAUK4MCjdfEbptPf7DFClxmo4Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.188.0.tgz",
+      "integrity": "sha512-kN2/nykNIYbGluNpgeYKEM0CUY8rGZJSLnBsvxMDjahZgK/9wu1EaOylgAEie/jS56Il1oAk3L2y1rQSMWHZMA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.188.0.tgz",
+      "integrity": "sha512-2607GbXHm/Dz3uKDbw3gzFBfVeVzGIt1++hv/hKe2LxYKN6f76zueU5RwJys19ZSZxKyrw/Ytn3vsYtZliJZxg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.188.0.tgz",
+      "integrity": "sha512-28t88xlVkHUcmYfOieMqa4iOwaBREaSvA2GPS8Re/5IGBu8+Sb2kouYVlp3YP4thR8OfPyW8liDeUYy0A/aqFw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.188.0.tgz",
+      "integrity": "sha512-4haypZJyQj2r4R8rV4ERdnCiNY1ufro52fUwpvOESpZGDM0Kwu3TaGoKUgOIUi6MZSinHJ5eaqsgcsTlo3wzgg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/service-error-classification": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/util-middleware": "3.188.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.188.0.tgz",
+      "integrity": "sha512-+16r+zZUQ3fe5FVz4AJ8C6XTt1JH4dqyzC0IkNUPAPQYwp7bp5k3AefnrqsaWvToQCCLH5V+ml6uaqEcmJHe0w==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.188.0",
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/signature-v4": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.188.0.tgz",
+      "integrity": "sha512-+0dw3ZPDEBv/DqSX9MmLQ2lPvxrO761pJXgDssYNVMY7C+PLB5pU6vKwXbmYAXk/FRwYyRjfKOf2WEvRwen0uw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.188.0.tgz",
+      "integrity": "sha512-zWCgKDknjg/wfJuqRCm37m2JXT3TFJyGpxxMwfG/V2qFc2pDlFOWKu9xeGksRl9tUuLRkecfZZ7asYWCDBzS8w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/signature-v4": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/util-middleware": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.188.0.tgz",
+      "integrity": "sha512-HuqP7hVnnx+aHfE6TutlMgjF0b2Ft08s9CDwyZ7ZhmYodQv/iPba7OGL4qz44oq7mdqlltN9sJkXczSAw0Zbaw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.188.0.tgz",
+      "integrity": "sha512-7+5lZ2bQWtLZ3YQvNrRRtzBTcVKSr1OBwoCm0+nu6dXbon7S2eeD74A6VzXfBDlhYJjNFa/iCch8TcszshkEzA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.188.0.tgz",
+      "integrity": "sha512-Oe9vDTyKAqSpYHLhuuwpIL73plkh5QlggYPL8qi8DmY5rbrwPOgRLD3R0u7PWwlXzHbGceN8bNT3tKrpADxlMQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/shared-ini-file-loader": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.188.0.tgz",
+      "integrity": "sha512-2MlxskooHm1kSyWHJqj60Mx0CWaIBtXnslHK+cdSSOrmAIuHybBCWzRSQYDkR96MA4+S0MUVFn6jpKF2St104g==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.188.0",
+        "@aws-sdk/protocol-http": "3.188.0",
+        "@aws-sdk/querystring-builder": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.188.0.tgz",
+      "integrity": "sha512-uRxLfSlo9F8W+A73VnHbBiOwGqXo1sPem0v/53ap76Nvf0114BCEWTSfBByt+h/miUMazS7oI5Qeh41Ht3NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.188.0.tgz",
+      "integrity": "sha512-9f5hTzcsQnl64HFUZsD61pT4kmAMgh7nYdPEUQcVmVy0X3rGsbf7CItjxp/tIG/OiJrsM7Rb6hM0gwZO4PHSdQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.188.0.tgz",
+      "integrity": "sha512-geECCF3Djo76dBly5gfm6Jo0R3/w7riXx8YNTps+H04FombWP9Dk7ZWa+EImXEpGaKq6/W8Emxduao9woT2H8A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.188.0.tgz",
+      "integrity": "sha512-QT6yLy0hVxOpCBENytwGj2d6V3NkltebCS+6aGPFzeduYuk+YxE1UkK41vhhhsCpJt5srW1zNDbaUzDRLMRGhQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.188.0.tgz",
+      "integrity": "sha512-hze+v3cCfNxk28X6viCr8fNkFRovnBwQmw2Ajyh+nzfmRP2tDK2TZThWwO13XFGtX2YQoy2/UFfOJqphMJsEUQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.188.0.tgz",
+      "integrity": "sha512-K0O56/ZN9Z9tbogvcgqJ1jdQ1qnH27/orfXMuduiaip2AXR4wWKmu1VfS91lQ18kaf+xU2zrS4ZioH956fXnfQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.188.0.tgz",
+      "integrity": "sha512-YRyXFWfbblcOuMm/gcd1MGRFiwxrzaMfnZs8OAqtxLyA4b+fT59C7z2XTAHbjBcCrYEbDR9kF7yPkjn1uxDO8g==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
+        "@aws-sdk/util-middleware": "3.188.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.188.0.tgz",
+      "integrity": "sha512-heJ1/++zOTU64CxbIRNm3hQgA2muln/HSUz4fDP8T0O8DwJwi9glvJcuoU0yatdjUELMKXMzgzsZSV/+F5EZ6g==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.188.0.tgz",
+      "integrity": "sha512-5z4ewjuRFPXYPCV3gaoHDCdjwrpBUs+12uZFBEbGE0S4UV+YrOPN5ehy+rpAGbhrsKYDxbAg9tHLkX4vRDFVgw==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.188.0.tgz",
+      "integrity": "sha512-KdLkmhuFOL7oPhkgVSIMBkaNXxwHqYsHmvZiGOFXT+q28u/Ho85i6ZqgY6FX+/6pfCiF12yDRTBNkqL6SnPwaQ==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
+      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
+      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
+      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.188.0.tgz",
+      "integrity": "sha512-exuym/vHTIn9kAIDgVFv/2WvCWuKu98DWPnGnG9Jm1pB1etNvD5xPHVTN8UIu0nQgWO0Mgq8Zv9rdlEerx/t4Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.188.0.tgz",
+      "integrity": "sha512-KE2y78qJ5wCiVf2YZVuD3CsrozhOeFeI816t0Kp0GN8q71TmyBK/FXR+3Uth6G5OCM6ytMCi6R7ZLJv1PqsQKQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.188.0",
+        "@aws-sdk/credential-provider-imds": "3.188.0",
+        "@aws-sdk/node-config-provider": "3.188.0",
+        "@aws-sdk/property-provider": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.188.0.tgz",
+      "integrity": "sha512-Rm2IFzr+b4M/N6aqYndqyCxnxlwtMMDtGU1uRxaOpVapskKpf8H0aF0U/FCN4t70x5HXql0l2Fv4d3CH9CRGig==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.188.0.tgz",
+      "integrity": "sha512-kgOey8X4fbHw0XHVur2gdA2ADyIIzbk6wZtu+X4M1ekxhBNb7taTNO5sa5s1mLId9/tQ+DwLyPQFtZczlAaqLg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.188.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.188.0.tgz",
+      "integrity": "sha512-apIuMf+VMODmt2HWIt8Ywlk30KajaHJiSvssvyZvRXrprV8ic9Pb+1/AKh0D7XBaJq5HwXFCRwG5P4ryr37Yfg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
         }
       }
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
-    "buffer-writer": {
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
+      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.188.0.tgz",
+      "integrity": "sha512-Vw+lMqvwfPOz3/eB8Dqq1VgmeU398dGxWJROJk6yOpBb5BZcvw/8woj8NWZiKxe2gNmVPdrgVSiE+lx3twMF6g==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.188.0",
+        "@aws-sdk/types": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.0.tgz",
+      "integrity": "sha512-yhxwIlFVSVcMym3O31HoMnRXpoenmpIxcj4Yoes2DUpe+xCJnA7ECQP1Vw889V0jTt/2nzvpLQ/UuMYCd3JPIg==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.17.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.1.tgz",
+      "integrity": "sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw=="
+    },
+    "node_modules/@types/pg": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.10.2.tgz",
+      "integrity": "sha512-MKFs9P6nJ+LAeHLU3V0cODEOgyThJ3OAnmOlsZsxux6sfQs3HRXR5bBn7xG5DjckEFhTAxsXi7k7cd0pCMxpJw==",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.1.tgz",
+      "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.0.1",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.0.1.tgz",
+      "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "packet-reader": {
+    "node_modules/packet-reader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
-    "pg": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
-      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
-      "requires": {
+    "node_modules/pg": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.2.tgz",
+      "integrity": "sha512-l4rmVeV8qTIrrPrIR3kZQqBgSN93331s9i6wiUiLOSk0Q7PmUxZD/m1rQI622l3NfqBby9Ar5PABfS/SulfieQ==",
+      "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.3.0",
-        "pg-protocol": "^1.5.0",
+        "pg-connection-string": "^2.6.2",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
-    "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
     },
-    "pg-int8": {
+    "node_modules/pg-connection-string": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+    },
+    "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
-    "pg-pool": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
-      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg=="
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "pg-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    "node_modules/pg-pool": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
     },
-    "pg-types": {
+    "node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "requires": {
+      "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
         "postgres-bytea": "~1.0.0",
         "postgres-date": "~1.0.4",
         "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "pgpass": {
+    "node_modules/pgpass": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
       "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
-      "requires": {
+      "dependencies": {
         "split2": "^3.1.1"
       }
     },
-    "postgres-array": {
+    "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "postgres-bytea": {
+    "node_modules/postgres-bytea": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "postgres-date": {
+    "node_modules/postgres-date": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "postgres-interval": {
+    "node_modules/postgres-interval": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "requires": {
+      "dependencies": {
         "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    "node_modules/postgres-range": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
+      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g=="
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "readable-stream": {
+    "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
+      "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-    },
-    "split2": {
+    "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "requires": {
+      "dependencies": {
         "readable-stream": "^3.0.0"
       }
     },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
+      "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
-    "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
-      "dev": true
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+    "node_modules/tslib": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+    },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
-    "util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xtend": {
+    "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/rds/postgres/management_lambda/src/package.json
+++ b/rds/postgres/management_lambda/src/package.json
@@ -3,18 +3,18 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@types/node": "^12.20.13",
-    "@types/pg": "^8.6.0",
-    "aws-sdk": "^2.918.0",
-    "pg": "^8.6.0",
-    "pg-connection-string": "^2.5.0"
+    "@types/node": "^18.17.1",
+    "@types/pg": "^8.10.2",
+    "@aws-sdk/client-ssm": "3.188.0",
+    "pg": "^8.11.2",
+    "pg-connection-string": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node12": "^1.0.7",
-    "@vercel/ncc": "^0.28.6",
-    "typescript": "^4.3.2"
+    "@tsconfig/node18": "^18.2.0",
+    "@vercel/ncc": "^0.36.1",
+    "typescript": "^5.1.6"
   },
   "scripts": {
-    "build": "ncc build index.ts --external 'aws-sdk/clients/ssm' --target es2020 --out ../dist --license index.js.license"
+    "build": "ncc build index.ts --external '@aws-sdk/client-ssm' --target es2020 --out ../dist --license index.js.license"
   }
 }

--- a/rds/postgres/management_lambda/src/tsconfig.json
+++ b/rds/postgres/management_lambda/src/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "@tsconfig/node12",
+  "extends": "@tsconfig/node18",
   "compilerOptions": {
     "noEmit": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "esModuleInterop": true
   },
   "include": ["**/*"],
   "exclude": ["node_modules"]

--- a/spa/middleware/README.md
+++ b/spa/middleware/README.md
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_handler"></a> [handler](#input\_handler) | Path to the function which will handle lambda calls | `string` | `"index.handler"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Lambda name | `string` | n/a | yes |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | Role which should be assumed by the Lambda, created by middleware\_common module | `string` | n/a | yes |
-| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda runtime | `string` | `"nodejs10.x"` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda runtime | `string` | `"nodejs18.x"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to resources that support them | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/spa/middleware/variables.tf
+++ b/spa/middleware/variables.tf
@@ -27,7 +27,7 @@ variable "role_arn" {
 variable "runtime" {
   description = "Lambda runtime"
   type        = string
-  default     = "nodejs10.x"
+  default     = "nodejs18.x"
 }
 
 variable "handler" {


### PR DESCRIPTION
Updated default nodejs runtime from 10.x and 12.x to 18.x, which is the latest LTS release.

**Breaking change**

Breaking users of default values, check if your lambda code uses anything that was changed between node 12 and node 18.