### PR TITLE
fix(rds/postgres/management_lambda): always connect with ssl

### DIFF
--- a/rds/postgres/management_lambda/dist/index.js
+++ b/rds/postgres/management_lambda/dist/index.js
@@ -8596,7 +8596,7 @@ async function handler({ database, queries }) {
         database: clientConfig.database ?? undefined,
         host: clientConfig.host ?? undefined,
         port: clientConfig.port ? Number(clientConfig.port) : undefined,
-        ssl: Boolean(clientConfig.ssl),
+        ssl: true,
     });
     await client.connect();
     try {

--- a/rds/postgres/management_lambda/src/index.ts
+++ b/rds/postgres/management_lambda/src/index.ts
@@ -25,7 +25,7 @@ export async function handler({ database, queries }: Event) {
     database: clientConfig.database ?? undefined,
     host: clientConfig.host ?? undefined,
     port: clientConfig.port ? Number(clientConfig.port) : undefined,
-    ssl: Boolean(clientConfig.ssl),
+    ssl: true,
   })
   await client.connect()
 


### PR DESCRIPTION
AWS has changed default postgres config to force SSL connections. Changed our management lambda to always use SSL, which should work for both old and new RDS instances.