### PR TITLE
feat(ecs/services): added wait_for_steady_state to ECS services

### DIFF
--- a/ecs/services/statsd/README.md
+++ b/ecs/services/statsd/README.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name for the service and task definition | `string` | `"statsd"` | no |
 | <a name="input_port"></a> [port](#input\_port) | Port to listen on on each ECS instance | `number` | `8125` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to resources | `map(string)` | `{}` | no |
+| <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Wait for the service to reach a steady state | `bool` | `true` | no |
 
 ## Outputs
 

--- a/ecs/services/statsd/main.tf
+++ b/ecs/services/statsd/main.tf
@@ -129,6 +129,9 @@ resource "aws_ecs_service" "service" {
   task_definition     = aws_ecs_task_definition.task[0].arn
   launch_type         = "EC2"
   scheduling_strategy = "DAEMON"
+
+  wait_for_steady_state = var.wait_for_steady_state
+
 }
 
 # outputs

--- a/ecs/services/statsd/variables.tf
+++ b/ecs/services/statsd/variables.tf
@@ -44,3 +44,9 @@ variable "debug" {
   type        = bool
   default     = false
 }
+
+variable "wait_for_steady_state" {
+  description = "Wait for the service to reach a steady state"
+  type        = bool
+  default     = true
+}

--- a/ecs/services/web/README.md
+++ b/ecs/services/web/README.md
@@ -81,6 +81,7 @@ Creates an ECS service exposed to the internet using an Application Load Balance
 | <a name="input_task_definition_arn"></a> [task\_definition\_arn](#input\_task\_definition\_arn) | ECS task definition ARN to run as a service | `string` | n/a | yes |
 | <a name="input_unhealthy_threshold"></a> [unhealthy\_threshold](#input\_unhealthy\_threshold) | The number of consecutive health check failures required before considering the target unhealthy | `number` | `2` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id | `string` | n/a | yes |
+| <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Wait for the service to reach a steady state | `bool` | `true` | no |
 
 ## Outputs
 

--- a/ecs/services/web/main.tf
+++ b/ecs/services/web/main.tf
@@ -35,6 +35,8 @@ resource "aws_ecs_service" "service" {
   deployment_minimum_healthy_percent = var.deployment_min_percent
   iam_role                           = var.role_arn
 
+  wait_for_steady_state = var.wait_for_steady_state
+
   load_balancer {
     target_group_arn = aws_lb_target_group.service[0].arn
     container_name   = local.container

--- a/ecs/services/web/variables.tf
+++ b/ecs/services/web/variables.tf
@@ -142,3 +142,8 @@ variable "unhealthy_threshold" {
   default     = 2
 }
 
+variable "wait_for_steady_state" {
+  description = "Wait for the service to reach a steady state"
+  type        = bool
+  default     = true
+}

--- a/ecs/services/worker/README.md
+++ b/ecs/services/worker/README.md
@@ -50,6 +50,7 @@ Creates an ECS service for background workers
 | <a name="input_launch_type"></a> [launch\_type](#input\_launch\_type) | The launch type on which to run your service. Either EC2 or FARGATE. | `string` | `"EC2"` | no |
 | <a name="input_name"></a> [name](#input\_name) | ECS service name | `string` | n/a | yes |
 | <a name="input_task_definition_arn"></a> [task\_definition\_arn](#input\_task\_definition\_arn) | ECS task definition ARN to run as a service | `string` | n/a | yes |
+| <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Wait for the service to reach a steady state | `bool` | `true` | no |
 
 ## Outputs
 

--- a/ecs/services/worker/main.tf
+++ b/ecs/services/worker/main.tf
@@ -20,6 +20,8 @@ resource "aws_ecs_service" "service" {
   deployment_maximum_percent         = var.deployment_max_percent
   deployment_minimum_healthy_percent = var.deployment_min_percent
 
+  wait_for_steady_state = var.wait_for_steady_state
+
   lifecycle {
     create_before_destroy = true
   }

--- a/ecs/services/worker/variables.tf
+++ b/ecs/services/worker/variables.tf
@@ -43,3 +43,8 @@ variable "deployment_max_percent" {
   default     = 200
 }
 
+variable "wait_for_steady_state" {
+  description = "Wait for the service to reach a steady state"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Added `wait_for_steady_state` variable to all ECS service modules:

- `ecs/services/worker`
- `ecs/services/web`
- `ecs/services/statsd`

`wait_for_steady_state = true`, which is the default, will cause terraform to wait until the service deployment has finished, which should help with detecting deployment issues.