### PR TITLE
fix(redis): apply changes immediately

### DIFF
--- a/elasticache/redis/README.md
+++ b/elasticache/redis/README.md
@@ -4,20 +4,21 @@ Creates an Elasticache Redis cluster
 
 ## Inputs
 
-| Name                   | Description                                                                                         |  Type  |       Default        | Required |
-| ---------------------- | --------------------------------------------------------------------------------------------------- | :----: | :------------------: | :------: |
-| environment            | Kebab-cased environment name, eg. development, staging, production                                  | string |         n/a          |   yes    |
-| id                     | Elasticache cluster id, defaults to project-environment, 1 to 20 alphanumeric characters or hyphens | string |         `""`         |    no    |
-| instance\_count        | Number of instances to create in the cluster                                                        | string |        `"1"`         |    no    |
-| instance\_type         | The instance type of the Elasticache cluster, eg. cache.t2.micro                                    | string |         n/a          |   yes    |
-| parameter\_group\_name | Elasticache parameter group, needs to be adjusted along with the version                            | string | `"default.redis5.0"` |    no    |
-| port                   | The port on which Redis should accept connections                                                   | string |       `"6379"`       |    no    |
-| project                | Kebab-cased project name                                                                            | string |         n/a          |   yes    |
-| redis\_version         | Elasticache Redis engine version                                                                    | string |      `"5.0.6"`       |    no    |
-| security\_group\_ids   | Security group ids which should have access to Redis                                                |  list  |       `<list>`       |    no    |
-| subnet\_ids            | VPC subnet IDs in which Redis should be created                                                     |  list  |         n/a          |   yes    |
-| tags                   | Tags to add to resources that support them                                                          |  map   |       `<map>`        |    no    |
-| vpc\_id                | VPC ID in which Redis should be created                                                             | string |         n/a          |   yes    |
+| Name                 | Description                                                                                         |  Type   |       Default        | Required |
+| -------------------- | --------------------------------------------------------------------------------------------------- | :-----: | :------------------: | :------: |
+| environment          | Kebab-cased environment name, eg. development, staging, production                                  | string  |         n/a          |   yes    |
+| id                   | Elasticache cluster id, defaults to project-environment, 1 to 20 alphanumeric characters or hyphens | string  |         `""`         |    no    |
+| instance_count       | Number of instances to create in the cluster                                                        | string  |        `"1"`         |    no    |
+| instance_type        | The instance type of the Elasticache cluster, eg. cache.t2.micro                                    | string  |         n/a          |   yes    |
+| parameter_group_name | Elasticache parameter group, needs to be adjusted along with the version                            | string  | `"default.redis5.0"` |    no    |
+| port                 | The port on which Redis should accept connections                                                   | string  |       `"6379"`       |    no    |
+| project              | Kebab-cased project name                                                                            | string  |         n/a          |   yes    |
+| redis_version        | Elasticache Redis engine version                                                                    | string  |      `"5.0.6"`       |    no    |
+| security_group_ids   | Security group ids which should have access to Redis                                                |  list   |       `<list>`       |    no    |
+| subnet_ids           | VPC subnet IDs in which Redis should be created                                                     |  list   |         n/a          |   yes    |
+| tags                 | Tags to add to resources that support them                                                          |   map   |       `<map>`        |    no    |
+| vpc_id               | VPC ID in which Redis should be created                                                             | string  |         n/a          |   yes    |
+| apply_immediately    | Whether to apply changes immediately, possibly incuring downtime                                    | boolean |        `true`        |    no    |
 
 ## Outputs
 
@@ -28,4 +29,3 @@ Creates an Elasticache Redis cluster
 | port  | Redis port                          |
 | url   | First Redis instance connection url |
 | urls  | Redis connection urls               |
-

--- a/elasticache/redis/main.tf
+++ b/elasticache/redis/main.tf
@@ -43,6 +43,7 @@ resource "aws_elasticache_cluster" "cache" {
   port                 = "${var.port}"
   subnet_group_name    = "${aws_elasticache_subnet_group.cache.name}"
   security_group_ids   = ["${aws_security_group.cache.id}"]
+  apply_immediately    = "${var.apply_immediately}"
 
   tags = "${local.tags}"
 }

--- a/elasticache/redis/variables.tf
+++ b/elasticache/redis/variables.tf
@@ -54,3 +54,8 @@ variable "instance_count" {
   description = "Number of instances to create in the cluster"
   default     = 1
 }
+
+variable "apply_immediately" {
+  description = "Whether to apply changes immediately, possibly incuring downtime"
+  default     = true
+}


### PR DESCRIPTION
Added `apply_immediately` variable to `elasticache/redis`, which is enabled by default, to force AWS to apply changes now, instead of scheduling them for the next maintenance window.